### PR TITLE
Fix 404 errors on page refresh by adding SPA fallback

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,9 @@
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+# SPA fallback - serve index.html for all routes that don't match files
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Purpose

The user was experiencing 404 errors when refreshing pages after deploying their project to Netlify. This is a common issue with Single Page Applications (SPAs) where client-side routing doesn't work properly without server-side configuration to handle route fallbacks.

## Code changes

Added a new redirect rule in `netlify.toml` to implement SPA fallback behavior:
- Added a catch-all redirect (`/*`) that serves `index.html` for any route that doesn't match existing files
- Set status code to 200 to ensure proper handling
- This allows the client-side router to handle routing after the initial page load

This configuration ensures that all routes are properly handled by the SPA, preventing 404 errors on page refresh or direct URL access.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/91d4f531c4c94bee86ae4c0e7e9205ea/pixel-field)

👀 [Preview Link](https://91d4f531c4c94bee86ae4c0e7e9205ea-pixel-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>91d4f531c4c94bee86ae4c0e7e9205ea</projectId>-->
<!--<branchName>pixel-field</branchName>-->