### PR TITLE
Fix mobile UI and add visual feedback for word cards

### DIFF
--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -69,7 +69,9 @@ export function InteractiveDashboardWordCard({
   const [isAnswered, setIsAnswered] = useState(false);
   const [celebrationEffect, setCelebrationEffect] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [feedbackType, setFeedbackType] = useState<"remembered" | "needs_practice" | null>(null);
+  const [feedbackType, setFeedbackType] = useState<
+    "remembered" | "needs_practice" | null
+  >(null);
   const [guess, setGuess] = useState("");
   const [showHint, setShowHint] = useState(false);
 
@@ -181,18 +183,18 @@ export function InteractiveDashboardWordCard({
       // Show feedback overlay if user has answered
       if (feedbackType) {
         const feedbackEmoji = feedbackType === "remembered" ? "🎉" : "💪";
-        const feedbackColor = feedbackType === "remembered"
-          ? "from-green-100 to-green-200"
-          : "from-orange-100 to-orange-200";
-        const feedbackMessage = feedbackType === "remembered"
-          ? "Great job!"
-          : "Keep practicing!";
+        const feedbackColor =
+          feedbackType === "remembered"
+            ? "from-green-100 to-green-200"
+            : "from-orange-100 to-orange-200";
+        const feedbackMessage =
+          feedbackType === "remembered" ? "Great job!" : "Keep practicing!";
 
         return (
-          <div className={`w-48 h-32 mx-auto flex flex-col items-center justify-center bg-gradient-to-br ${feedbackColor} rounded-2xl shadow-lg border-2 ${feedbackType === "remembered" ? "border-green-300" : "border-orange-300"} transition-all duration-500`}>
-            <div className="text-4xl animate-bounce mb-1">
-              {feedbackEmoji}
-            </div>
+          <div
+            className={`w-48 h-32 mx-auto flex flex-col items-center justify-center bg-gradient-to-br ${feedbackColor} rounded-2xl shadow-lg border-2 ${feedbackType === "remembered" ? "border-green-300" : "border-orange-300"} transition-all duration-500`}
+          >
+            <div className="text-4xl animate-bounce mb-1">{feedbackEmoji}</div>
             <div className="text-xs font-bold text-gray-700">
               {feedbackMessage}
             </div>
@@ -419,7 +421,9 @@ export function InteractiveDashboardWordCard({
                 >
                   <XCircle className="w-5 h-5 mr-1 md:w-8 md:h-8 md:mr-3" />
                   <div className="text-center">
-                    <div className="font-bold text-lg md:text-2xl">😔 I Forgot</div>
+                    <div className="font-bold text-lg md:text-2xl">
+                      😔 I Forgot
+                    </div>
                     <div className="text-sm opacity-75 mt-1">
                       Need more practice
                     </div>
@@ -432,7 +436,9 @@ export function InteractiveDashboardWordCard({
                 >
                   <CheckCircle className="w-5 h-5 mr-1 md:w-8 md:h-8 md:mr-3" />
                   <div className="text-center">
-                    <div className="font-bold text-lg md:text-2xl">😊 I Remember</div>
+                    <div className="font-bold text-lg md:text-2xl">
+                      😊 I Remember
+                    </div>
                     <div className="text-sm opacity-75 mt-1">Got it right!</div>
                   </div>
                 </Button>

--- a/client/components/LearningDashboard.tsx
+++ b/client/components/LearningDashboard.tsx
@@ -76,7 +76,8 @@ export const LearningDashboard: React.FC<LearningDashboardProps> = ({
   );
 
   // Use actual word progress if childStats is available
-  const actualWordsLearned = childStats?.wordsRemembered || stats.weeklyProgress;
+  const actualWordsLearned =
+    childStats?.wordsRemembered || stats.weeklyProgress;
   const actualGoal = stats.weeklyGoal;
   const actualPercentage = Math.round((actualWordsLearned / actualGoal) * 100);
 
@@ -106,7 +107,9 @@ export const LearningDashboard: React.FC<LearningDashboardProps> = ({
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="flex items-center gap-2">
-                <span className="text-2xl">{getProgressEmoji(actualPercentage)}</span>
+                <span className="text-2xl">
+                  {getProgressEmoji(actualPercentage)}
+                </span>
                 <div>
                   <span className="text-sm font-bold text-slate-800">
                     Today's Word Quest
@@ -126,7 +129,9 @@ export const LearningDashboard: React.FC<LearningDashboardProps> = ({
                   {actualWordsLearned}/{actualGoal} words
                 </Badge>
                 <div className="text-xs font-semibold text-educational-blue mt-1">
-                  {actualPercentage >= 100 ? "Quest Complete!" : `${actualPercentage}% done`}
+                  {actualPercentage >= 100
+                    ? "Quest Complete!"
+                    : `${actualPercentage}% done`}
                 </div>
               </div>
               <div className="flex flex-col items-center gap-1">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -70,7 +70,6 @@ import { useNavigate } from "react-router-dom";
 import { WordProgressAPI } from "@/lib/wordProgressApi";
 import { ChildWordStats } from "@shared/api";
 
-
 interface IndexProps {
   initialProfile?: any;
 }
@@ -127,9 +126,17 @@ export default function Index({ initialProfile }: IndexProps) {
     currentStreak: 7,
     weeklyGoal: 20,
     weeklyProgress: rememberedWords.size, // Use actual remembered words for today's goal
-    accuracyRate: rememberedWords.size > 0 ? Math.round((rememberedWords.size / (rememberedWords.size + forgottenWords.size)) * 100) : 0,
+    accuracyRate:
+      rememberedWords.size > 0
+        ? Math.round(
+            (rememberedWords.size /
+              (rememberedWords.size + forgottenWords.size)) *
+              100,
+          )
+        : 0,
     favoriteCategory: "Animals",
-    totalPoints: rememberedWords.size * 50 + (rememberedWords.size > 10 ? 500 : 0), // Dynamic points
+    totalPoints:
+      rememberedWords.size * 50 + (rememberedWords.size > 10 ? 500 : 0), // Dynamic points
     level: Math.floor(rememberedWords.size / 5) + 1, // Level up every 5 words
     badges: [
       {


### PR DESCRIPTION
## Purpose

This PR addresses multiple mobile UI improvements and functionality enhancements based on user feedback:

- Reduce font sizes to fit better within containers
- Optimize button layout for mobile devices with side-by-side arrangement
- Fix navigation issues for Quick Quiz and Practice components
- Enhance visual feedback system for "I remember" and "I forgot" actions
- Improve overall mobile user experience

## Code changes

### InteractiveDashboardWordCard.tsx
- **Visual feedback system**: Added `feedbackType` state to show celebration/practice feedback overlays when users click "I remember" or "I forgot"
- **Font size reduction**: Decreased word title from `text-4xl md:text-5xl` to `text-2xl md:text-3xl` to fit containers better
- **Mobile button optimization**: Changed button grid from `grid-cols-1 md:grid-cols-2` to `grid-cols-2` for consistent side-by-side layout
- **Button sizing**: Reduced padding from `py-8` to `py-3 px-2` and icon sizes for mobile (`w-5 h-5` on mobile, `w-8 h-8` on desktop)
- **Container sizing**: Reduced image container from `w-full h-64` to `w-48 h-32 mx-auto` for better proportions
- **Hidden definition section**: Temporarily hid definition/example section to focus on word display

### LearningDashboard.tsx
- **Real-time progress tracking**: Updated progress indicators to use actual `childStats.wordsRemembered` data instead of static values
- **Kid-friendly messaging**: Added dynamic progress messages and emojis based on completion percentage
- **Enhanced visual design**: Improved progress bar styling with better animations and trophy icons for completion

### Index.tsx
- **Dynamic stats calculation**: Replaced static learning stats with real-time calculations based on `rememberedWords` and `forgottenWords` sets
- **Navigation fixes**: Added proper tab navigation when clicking Quick Quiz (`setActiveTab("quiz")`) and Practice (`setActiveTab("learn")`)
- **Badge system**: Made badge earning dynamic based on actual progress milestones
- **Mobile header cleanup**: Temporarily hid some mobile header elements for cleaner layout

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7673e4d8daa746a4bacf43f700c4d21b/curry-verse)

👀 [Preview Link](https://7673e4d8daa746a4bacf43f700c4d21b-curry-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7673e4d8daa746a4bacf43f700c4d21b</projectId>-->
<!--<branchName>curry-verse</branchName>-->