### PR TITLE
Improve mobile UX: larger emojis and compact layout

### DIFF
--- a/client/components/WordCard.tsx
+++ b/client/components/WordCard.tsx
@@ -298,7 +298,9 @@ export const WordCard: React.FC<WordCardProps> = ({
                   }}
                   disabled={isPlaying}
                   className={`text-white hover:bg-white/30 hover:scale-110 p-3 h-auto rounded-full transition-all duration-300 border-2 border-white/40 bg-white/10 backdrop-blur-sm shadow-lg ${
-                    isPlaying ? "scale-125 bg-yellow-400/30 border-yellow-300/60 shadow-yellow-300/30 animate-bounce" : "hover:border-white/60"
+                    isPlaying
+                      ? "scale-125 bg-yellow-400/30 border-yellow-300/60 shadow-yellow-300/30 animate-bounce"
+                      : "hover:border-white/60"
                   }`}
                 >
                   <Volume2


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR enhances the WordCard component to be more kid-friendly and mobile-optimized by:
- Increasing emoji size for better visibility for children
- Reducing spacing between elements to create a more compact, mobile-friendly layout
- Ensuring all content fits properly within the card boundaries on mobile devices

## Code changes

**Front card improvements:**
- Increased card width from `max-w-xs` to `max-w-sm` for better content fit
- Reduced card height from `h-[360px]` to `h-[320px]` on mobile for compactness
- Decreased padding from `p-3` to `p-2` on mobile to maximize content space
- Significantly enlarged emoji size from `text-3xl` to `text-6xl` (mobile) and up to `text-8xl` (desktop)
- Enhanced speaker button with larger size, better styling, and improved visual feedback
- Reduced margins and spacing throughout for tighter layout

**Back card improvements:**
- Reduced padding from `p-4` to `p-2` on mobile for better content fit
- Decreased font sizes and spacing for definition, example, and fun fact sections
- Compressed adventure features section with smaller margins and padding
- Optimized text hierarchy to fit more content in limited mobile space

These changes ensure the card content is fully visible and accessible on mobile devices while making the interface more engaging for children through larger, more prominent emojis and interactive elements.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 37`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0f75963ae22d496c94f2ec37219c78dc/nova-oasis)

👀 [Preview Link](https://0f75963ae22d496c94f2ec37219c78dc-nova-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0f75963ae22d496c94f2ec37219c78dc</projectId>-->
<!--<branchName>nova-oasis</branchName>-->