### PR TITLE
Reduce achievement popup auto-close delay to 3 seconds

### DIFF
--- a/client/components/EnhancedAchievementPopup.tsx
+++ b/client/components/EnhancedAchievementPopup.tsx
@@ -163,7 +163,7 @@ export function EnhancedAchievementPopup({
   achievements,
   onClose,
   onAchievementClaim,
-  autoCloseDelay = 8000, // Default 8 seconds
+  autoCloseDelay = 3000, // Default 3 seconds
 }: EnhancedAchievementPopupProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [showReward, setShowReward] = useState(false);


### PR DESCRIPTION
## Purpose
The user requested to enhance the achievement popup message by reducing the auto-close timer from the current 8 seconds to 3 seconds for a better user experience.

## Code changes
- Updated the default `autoCloseDelay` parameter in `EnhancedAchievementPopup.tsx` from 8000ms (8 seconds) to 3000ms (3 seconds)
- This change affects the automatic dismissal timing of achievement popup notifications

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ff51c147507c42498ac76e24a783dcd1/flare-landing)

👀 [Preview Link](https://ff51c147507c42498ac76e24a783dcd1-flare-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ff51c147507c42498ac76e24a783dcd1</projectId>-->
<!--<branchName>flare-landing</branchName>-->