### PR TITLE
Reduce achievement popup auto-close delay from 5s to 3s

### DIFF
--- a/client/components/EnhancedMobileWordCard.tsx
+++ b/client/components/EnhancedMobileWordCard.tsx
@@ -1000,7 +1000,7 @@ export const EnhancedMobileWordCard: React.FC<EnhancedMobileWordCardProps> = ({
           onAchievementClaim={(achievement) => {
             console.log("Word mastery achievement claimed:", achievement);
           }}
-          autoCloseDelay={5000}
+          autoCloseDelay={3000}
         />
       )}
 

--- a/client/components/EnhancedWordCard.tsx
+++ b/client/components/EnhancedWordCard.tsx
@@ -783,7 +783,7 @@ export const EnhancedWordCard: React.FC<EnhancedWordCardProps> = ({
           onAchievementClaim={(achievement) => {
             console.log("Word mastery achievement claimed:", achievement);
           }}
-          autoCloseDelay={5000}
+          autoCloseDelay={3000}
         />
       )}
     </div>

--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -1499,7 +1499,7 @@ export function InteractiveDashboardWordCard({
             );
             // Could add additional reward logic here
           }}
-          autoCloseDelay={5000} // Auto-close after 5 seconds
+          autoCloseDelay={3000} // Auto-close after 3 seconds
         />
       )}
     </div>

--- a/client/components/WordCard.tsx
+++ b/client/components/WordCard.tsx
@@ -911,7 +911,7 @@ export const WordCard: React.FC<WordCardProps> = ({
             console.log("Word mastery achievement claimed:", achievement);
             // Could add additional reward logic here
           }}
-          autoCloseDelay={5000} // Auto-close after 5 seconds for word achievements
+          autoCloseDelay={3000} // Auto-close after 3 seconds for word achievements
         />
       )}
 


### PR DESCRIPTION
## Purpose
The user requested to reduce the auto-close timing for enhanced achievement popups to improve user experience by making them dismiss more quickly, changing from 5 seconds to 3 seconds.

## Code changes
Updated the `autoCloseDelay` parameter from 5000ms to 3000ms across four word card components:
- `EnhancedMobileWordCard.tsx`
- `EnhancedWordCard.tsx` 
- `InteractiveDashboardWordCard.tsx`
- `WordCard.tsx`

This ensures all achievement popups consistently auto-close after 3 seconds instead of 5 seconds.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 64`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ff51c147507c42498ac76e24a783dcd1/curry-space)

👀 [Preview Link](https://ff51c147507c42498ac76e24a783dcd1-curry-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ff51c147507c42498ac76e24a783dcd1</projectId>-->
<!--<branchName>curry-space</branchName>-->