### PR TITLE
Fix WordGarden game progression and audio service errors

### DIFF
--- a/client/components/games/WordGarden.tsx
+++ b/client/components/games/WordGarden.tsx
@@ -12,7 +12,7 @@ import { EnhancedAchievementTracker } from "@/lib/enhancedAchievementTracker";
 /**
  * Word Garden — Listen & Pick Game for Ages 3–5
  * -------------------------------------------------
- * • Pulls words from your website DB using existing word service
+ * �� Pulls words from your website DB using existing word service
  * • Kids listen to pronunciation then pick the matching picture
  * • Every correct answer grows a plant in the garden (visual progress)
  * • Integrates with achievements + sparkle celebration hooks
@@ -360,7 +360,7 @@ export default function WordGardenGame({
         setStreak(0);
 
         // Play incorrect sound
-        audioService.playIncorrectSound();
+        audioService.playEncouragementSound();
 
         // gentle buzz
         if (navigator && "vibrate" in navigator)


### PR DESCRIPTION
## Purpose

Users reported that the WordGarden game was not functioning properly after answering the first question - it failed to automatically progress to the next word. Additionally, there were JavaScript errors preventing the game from working:
- `EnhancedAchievementTracker.getInstance is not a function` 
- `audioService.playCorrectSound is not a function`

The goal was to fix these critical bugs to restore proper game functionality and automatic progression between questions.

## Code Changes

- **Fixed achievement tracking**: Replaced deprecated `EnhancedAchievementTracker.getInstance()` calls with static `trackActivity()` method
- **Fixed audio service calls**: Updated method names from `playCorrectSound()` to `playSuccessSound()` and `playIncorrectSound()` to `playEncouragementSound()`
- **Improved game progression logic**: Enhanced round advancement logic to properly calculate next round and update best streak
- **Fixed emoji rendering**: Changed from base64 encoding to URL encoding to resolve Unicode display issues
- **Cleaned up dependencies**: Removed unused `attempts` dependency from useCallback hook

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 71`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cb9a9e3b3d524f4ead5b87e79788e79c/aura-oasis)

👀 [Preview Link](https://cb9a9e3b3d524f4ead5b87e79788e79c-aura-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cb9a9e3b3d524f4ead5b87e79788e79c</projectId>-->
<!--<branchName>aura-oasis</branchName>-->