### PR TITLE
Remove 🆕 New badge from word card component

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -2571,11 +2571,7 @@ export default function Index({ initialProfile }: IndexProps) {
                                                   </div>
                                                 );
                                               } else {
-                                                return (
-                                                  <div className="text-xs text-blue-600 font-medium">
-                                                    🆕 New
-                                                  </div>
-                                                );
+                                                return null;
                                               }
                                             })()}
                                           </div>


### PR DESCRIPTION
## Purpose
Remove the 🆕 New badge feature from the word card component as requested by the user. The badge was displaying "🆕 New" text in blue styling but is no longer needed.

## Code changes
- Removed the conditional rendering block that displayed the "🆕 New" badge
- Replaced the badge JSX element with `return null` to render nothing in that conditional branch
- Eliminated the blue text styling (`text-xs text-blue-600 font-medium`) associated with the badge

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 81`

🔗 [Edit in Builder.io](https://builder.io/app/projects/673f177fe1b640739f003122d740e3bc/orbit-nest)

👀 [Preview Link](https://673f177fe1b640739f003122d740e3bc-orbit-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>673f177fe1b640739f003122d740e3bc</projectId>-->
<!--<branchName>orbit-nest</branchName>-->