### PR TITLE
Remove "Mastered!" badge from word card progress display

### DIFF
--- a/client/components/EnhancedMobileWordCard.tsx
+++ b/client/components/EnhancedMobileWordCard.tsx
@@ -862,12 +862,7 @@ export const EnhancedMobileWordCard: React.FC<EnhancedMobileWordCardProps> = ({
                         <Shield className="w-4 h-4 text-yellow-400" />
                         <span className="text-yellow-300">Good Progress</span>
                       </>
-                    ) : (
-                      <>
-                        <Crown className="w-4 h-4 text-green-400" />
-                        <span className="text-green-300">Mastered!</span>
-                      </>
-                    )}
+                    ) : null}
                   </div>
                   <span className="text-white/60">
                     Missed {adventureStatus?.forget_count || 0}x


### PR DESCRIPTION
## Purpose
Remove the conditional rendering of the "Mastered!" badge from the word card component in the word library to simplify the progress display interface.

## Code changes
- Removed the else clause that displayed the "Mastered!" badge with Crown icon and green styling
- Replaced the conditional block with `null` to render nothing when the condition is not met
- Simplified the progress status display logic in `EnhancedMobileWordCard.tsx`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 84`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7b214faac57c464f958c5b26d41253f2/echo-works)

👀 [Preview Link](https://7b214faac57c464f958c5b26d41253f2-echo-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7b214faac57c464f958c5b26d41253f2</projectId>-->
<!--<branchName>echo-works</branchName>-->