### PR TITLE
Move desktop check after hooks in ParentDashboard

### DIFF
--- a/client/components/ParentDashboard.tsx
+++ b/client/components/ParentDashboard.tsx
@@ -505,18 +505,6 @@ export const ParentDashboard: React.FC<ParentDashboardProps> = ({
   // Check if we're on desktop FIRST, before any other hooks
   const isDesktop = useIsDesktop();
 
-  // If we're on desktop, render the enhanced desktop version
-  // This must be done before any other hooks to avoid hooks violation
-  if (isDesktop) {
-    return (
-      <ParentDashboardDesktop
-        children={propChildren}
-        sessions={sessions}
-        onNavigateBack={onNavigateBack}
-      />
-    );
-  }
-
   // Auth hook for guest mode checking
   const { isGuest, user } = useAuth();
   const navigate = useNavigate();
@@ -1014,7 +1002,7 @@ export const ParentDashboard: React.FC<ParentDashboardProps> = ({
               <div className="flex flex-col md:flex-row md:items-center justify-between gap-3 md:gap-0">
                 <div>
                   <h3 className="font-semibold text-base md:text-lg">
-                    Good Morning! 🌅
+                    Good Morning! ��
                   </h3>
                   <p className="text-xs md:text-sm text-slate-600">
                     {children.length} active learner
@@ -1508,6 +1496,18 @@ export const ParentDashboard: React.FC<ParentDashboardProps> = ({
     ),
     [selectedChild, handleOpenLearningGoals, handleAddChildClick, children],
   );
+
+  // If we're on desktop, render the enhanced desktop version
+  // This check is done after all hooks to avoid hooks violation
+  if (isDesktop) {
+    return (
+      <ParentDashboardDesktop
+        children={propChildren}
+        sessions={sessions}
+        onNavigateBack={onNavigateBack}
+      />
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">


### PR DESCRIPTION
## Changes Made

### Code Structure
- Moved the desktop check and early return for `ParentDashboardDesktop` from the beginning of the component to after all hooks are called
- Updated the comment to reflect that the check is now done "after all hooks to avoid hooks violation"

### Text Changes
- Modified the greeting text from "Good Morning! 🌅" to "Good Morning! ��" (emoji character change)

## Files Modified
- `client/components/ParentDashboard.tsx`

## Technical Details
The desktop check conditional return was relocated from line 510-517 to line 1500-1512, ensuring all React hooks are called before any conditional returns that could cause hooks order violations.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 114`

🔗 [Edit in Builder.io](https://builder.io/app/projects/faa64525a4494b2caeb2d2a9f906c260/quantum-space)

👀 [Preview Link](https://faa64525a4494b2caeb2d2a9f906c260-quantum-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>faa64525a4494b2caeb2d2a9f906c260</projectId>-->
<!--<branchName>quantum-space</branchName>-->