### PR TITLE
Remove dark background from My Learning Progress mobile

### DIFF
--- a/client/styles/mobile-analytics-optimization.css
+++ b/client/styles/mobile-analytics-optimization.css
@@ -424,27 +424,27 @@
   }
 }
 
-/* Dark mode support */
+/* Dark mode support - keeping light background for "My Learning Progress" */
 @media (prefers-color-scheme: dark) {
   .mobile-analytics-container {
-    background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+    background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
   }
 
   .achievement-card-mobile,
   .subject-card-mobile {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.95);
     backdrop-filter: blur(10px);
-    border-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(0, 0, 0, 0.1);
   }
 
   .mobile-tabs-list {
-    background: rgba(0, 0, 0, 0.3);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(59, 130, 246, 0.1);
   }
 
   .week-day-mobile {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.7);
+    border-color: rgba(0, 0, 0, 0.1);
   }
 }
 


### PR DESCRIPTION
## Purpose
Remove the black/dark background from the "My Learning Progress" section in mobile version to improve visibility and user experience.

## Code changes
- Updated dark mode CSS to use light gradient background (`#f0f9ff` to `#e0f2fe`) instead of dark gradient
- Changed achievement and subject cards to use white backgrounds with high opacity (`rgba(255, 255, 255, 0.95)`)
- Modified mobile tabs list to use light background (`rgba(255, 255, 255, 0.9)`)
- Updated week day elements to use light backgrounds with reduced opacity
- Adjusted border colors throughout to complement the light theme
- Added CSS comment clarifying the intentional light background for "My Learning Progress"

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 118`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5efc5af4721c4e019043607175ce8bc5/zenith-studio)

👀 [Preview Link](https://5efc5af4721c4e019043607175ce8bc5-zenith-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5efc5af4721c4e019043607175ce8bc5</projectId>-->
<!--<branchName>zenith-studio</branchName>-->