### PR TITLE
Move speaker button to right with kid-friendly gaming style

### DIFF
--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -1144,8 +1144,9 @@ export function InteractiveDashboardWordCard({
                   "min-w-[60px] min-h-[60px] sm:min-w-[70px] sm:min-h-[70px] md:min-w-[80px] md:min-h-[80px]",
                   "ring-4 ring-blue-200/30 hover:ring-blue-300/50",
                   "backdrop-blur-sm",
-                  isPlaying && "animate-pulse ring-yellow-400/60 shadow-yellow-400/30",
-                  "disabled:opacity-50 disabled:transform-none disabled:hover:scale-100"
+                  isPlaying &&
+                    "animate-pulse ring-yellow-400/60 shadow-yellow-400/30",
+                  "disabled:opacity-50 disabled:transform-none disabled:hover:scale-100",
                 )}
                 aria-label="🔊 Play pronunciation - Hear how to say this word!"
               >


### PR DESCRIPTION
## Purpose
The user requested to reposition the speaker button in the interactive dashboard to the right side and redesign it with a larger, kid-friendly gaming style appearance to improve the user experience for children.

## Code changes
- **Repositioned speaker button**: Moved the pronunciation button from the left side to the right side of the control group
- **Enhanced visual design**: Upgraded from simple button to gaming-style design with:
  - Larger size (lg instead of sm) with responsive sizing up to 80px
  - Gradient background (blue tones) with hover effects
  - Enhanced shadows, borders, and ring effects
  - Rounded corners (rounded-2xl) for softer appearance
  - Added backdrop blur and special animations
- **Improved accessibility**: Enhanced aria-label with emoji and descriptive text
- **Kid-friendly animations**: Added bounce animation and special visual effects when playing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 124`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5efc5af4721c4e019043607175ce8bc5/mystic-garden)

👀 [Preview Link](https://5efc5af4721c4e019043607175ce8bc5-mystic-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5efc5af4721c4e019043607175ce8bc5</projectId>-->
<!--<branchName>mystic-garden</branchName>-->