### PR TITLE
Remove search function from mobile word library categories

### DIFF
--- a/client/components/ChildFriendlyCategorySelector.tsx
+++ b/client/components/ChildFriendlyCategorySelector.tsx
@@ -592,7 +592,6 @@ export function ChildFriendlyCategorySelector({
 
       {/* Mobile Quick Categories - Search removed */}
       <div className="md:hidden mb-6 px-2">
-
         {/* Quick Categories Bar - All Categories */}
         {!searchTerm && (
           <div>


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested to remove the search categories function specifically for the mobile version of the word library. This change aims to simplify the mobile interface while maintaining search functionality on desktop devices.

## Code changes

- **Moved search bar to desktop-only**: Added `hidden md:block` classes to make the search functionality visible only on medium screens and larger
- **Removed mobile search section**: Eliminated the mobile-specific search input and results display from the mobile layout
- **Updated mobile section comment**: Changed comment from "Mobile Search and Quick Categories" to "Mobile Quick Categories - Search removed" to reflect the new structure
- **Preserved desktop functionality**: Desktop search bar remains fully functional with the same search, clear, and results display features

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 136`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2b1b22637aac40539e058cb3da1fdac6/vibe-studio)

👀 [Preview Link](https://2b1b22637aac40539e058cb3da1fdac6-vibe-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2b1b22637aac40539e058cb3da1fdac6</projectId>-->
<!--<branchName>vibe-studio</branchName>-->