### PR TITLE
Improve AI progress bar mobile UX and reposition green dot

### DIFF
--- a/client/components/AIEnhancedInteractiveDashboardWordCard.tsx
+++ b/client/components/AIEnhancedInteractiveDashboardWordCard.tsx
@@ -1017,7 +1017,6 @@ export function AIEnhancedInteractiveDashboardWordCard({
       tabIndex={0}
       onKeyDown={handleKeyDown}
     >
-
       {/* AI Insights Panel - Mobile Optimized */}
       {showAIInsights && (
         <Card className="bg-gradient-to-r from-blue-50 to-purple-50 border-blue-200">
@@ -1519,7 +1518,6 @@ export function AIEnhancedInteractiveDashboardWordCard({
                   {sessionStats.accuracy}% Accuracy
                 </Badge>
               </div>
-
             </div>
 
             {/* Picture Display with State Transitions */}
@@ -1755,12 +1753,22 @@ export function AIEnhancedInteractiveDashboardWordCard({
                 <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center gap-1">
                     <span className="text-xs sm:text-sm">🧠🎯</span>
-                    <h2 className="text-xs sm:text-base font-bold text-gray-800">AI Progress</h2>
+                    <h2 className="text-xs sm:text-base font-bold text-gray-800">
+                      AI Progress
+                    </h2>
                   </div>
                   <div className="flex items-center gap-1">
                     <span className="text-xs sm:text-sm">🚀</span>
-                    <span className="font-medium text-gray-700 text-xs sm:text-sm">{dailyGoal.completed}/{dailyGoal.target}</span>
-                    <span className="font-bold text-gray-800 text-xs sm:text-sm">({Math.round((dailyGoal.completed / dailyGoal.target) * 100)}%)</span>
+                    <span className="font-medium text-gray-700 text-xs sm:text-sm">
+                      {dailyGoal.completed}/{dailyGoal.target}
+                    </span>
+                    <span className="font-bold text-gray-800 text-xs sm:text-sm">
+                      (
+                      {Math.round(
+                        (dailyGoal.completed / dailyGoal.target) * 100,
+                      )}
+                      %)
+                    </span>
                   </div>
                 </div>
 
@@ -1768,7 +1776,9 @@ export function AIEnhancedInteractiveDashboardWordCard({
                 <div className="w-full bg-gray-200 rounded-full h-1 sm:h-2 mb-2">
                   <div
                     className="bg-gradient-to-r from-blue-500 to-purple-500 h-1 sm:h-2 rounded-full transition-all duration-300"
-                    style={{ width: `${Math.round((dailyGoal.completed / dailyGoal.target) * 100)}%` }}
+                    style={{
+                      width: `${Math.round((dailyGoal.completed / dailyGoal.target) * 100)}%`,
+                    }}
                   ></div>
                 </div>
 
@@ -1776,15 +1786,21 @@ export function AIEnhancedInteractiveDashboardWordCard({
                 <div className="flex items-center justify-between text-xs gap-1">
                   <div className="flex items-center gap-0.5 bg-yellow-100 px-1 py-0.5 rounded flex-1 justify-center">
                     <span>😊</span>
-                    <span className="font-medium">{sessionStats.wordsRemembered}</span>
+                    <span className="font-medium">
+                      {sessionStats.wordsRemembered}
+                    </span>
                   </div>
                   <div className="flex items-center gap-0.5 bg-orange-100 px-1 py-0.5 rounded flex-1 justify-center">
                     <span>💪</span>
-                    <span className="font-medium">{sessionStats.wordsForgotten}</span>
+                    <span className="font-medium">
+                      {sessionStats.wordsForgotten}
+                    </span>
                   </div>
                   <div className="flex items-center gap-0.5 bg-purple-100 px-1 py-0.5 rounded flex-1 justify-center">
                     <span>🎯</span>
-                    <span className="font-medium">{Math.round(confidenceLevel * 100)}%</span>
+                    <span className="font-medium">
+                      {Math.round(confidenceLevel * 100)}%
+                    </span>
                   </div>
                   <div className="text-purple-600 font-medium text-xs hidden sm:block">
                     🌟 AI: Great!
@@ -1793,7 +1809,9 @@ export function AIEnhancedInteractiveDashboardWordCard({
 
                 {/* Session progress - Ultra compact */}
                 <div className="mt-1 text-center text-xs text-gray-500">
-                  <span>{currentWordIndex + 1}/{SESSION_SIZE}</span>
+                  <span>
+                    {currentWordIndex + 1}/{SESSION_SIZE}
+                  </span>
                   {sessionProgress >= 100 && <span className="ml-1">🎉</span>}
                 </div>
               </div>

--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -1097,7 +1097,6 @@ export function InteractiveDashboardWordCard({
         </div>
       )}
 
-
       {/* Interactive Word Card */}
       <motion.div
         initial={{ opacity: 0, y: 20, scale: 0.95 }}
@@ -1672,12 +1671,18 @@ export function InteractiveDashboardWordCard({
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-1">
                       <span className="text-xs sm:text-sm">🧠🎯</span>
-                      <h2 className="text-xs sm:text-base font-bold text-gray-800">AI Progress</h2>
+                      <h2 className="text-xs sm:text-base font-bold text-gray-800">
+                        AI Progress
+                      </h2>
                     </div>
                     <div className="flex items-center gap-1">
                       <span className="text-xs sm:text-sm">🚀</span>
-                      <span className="font-medium text-gray-700 text-xs sm:text-sm">{dailyGoal.completed}/{dailyGoal.target}</span>
-                      <span className="font-bold text-gray-800 text-xs sm:text-sm">({dailyProgress}%)</span>
+                      <span className="font-medium text-gray-700 text-xs sm:text-sm">
+                        {dailyGoal.completed}/{dailyGoal.target}
+                      </span>
+                      <span className="font-bold text-gray-800 text-xs sm:text-sm">
+                        ({dailyProgress}%)
+                      </span>
                     </div>
                   </div>
 
@@ -1693,15 +1698,21 @@ export function InteractiveDashboardWordCard({
                   <div className="flex items-center justify-between text-xs gap-1">
                     <div className="flex items-center gap-0.5 bg-yellow-100 px-1 py-0.5 rounded flex-1 justify-center">
                       <span>😊</span>
-                      <span className="font-medium">{sessionStats.wordsRemembered}</span>
+                      <span className="font-medium">
+                        {sessionStats.wordsRemembered}
+                      </span>
                     </div>
                     <div className="flex items-center gap-0.5 bg-orange-100 px-1 py-0.5 rounded flex-1 justify-center">
                       <span>💪</span>
-                      <span className="font-medium">{sessionStats.wordsForgotten}</span>
+                      <span className="font-medium">
+                        {sessionStats.wordsForgotten}
+                      </span>
                     </div>
                     <div className="flex items-center gap-0.5 bg-purple-100 px-1 py-0.5 rounded flex-1 justify-center">
                       <span>����</span>
-                      <span className="font-medium">{sessionStats.accuracy}%</span>
+                      <span className="font-medium">
+                        {sessionStats.accuracy}%
+                      </span>
                     </div>
                     <div className="text-purple-600 font-medium text-xs hidden sm:block">
                       🌟 AI: Great!


### PR DESCRIPTION
## Purpose
The user requested several UI improvements to enhance the mobile experience and visibility of AI learning features:
- Ensure AI progress elements are visible in both regular and AI-enabled modes
- Move progress bar to be positioned under the "I forgot" and "I remember" buttons
- Optimize the layout specifically for mobile devices
- Remove the selected progress bar component
- Reposition the green activity indicator dot to appear after "AI Learning Active!" text
- Reduce the height of the AI progress bar on mobile to improve user experience

## Code changes
- **Repositioned green dot**: Moved the green activity indicator from absolute positioning to inline after the "AI Learning Active!" text
- **Removed old progress bar**: Eliminated the session progress bar that was previously displayed when AI was active
- **Added new mobile-optimized progress bar**: Created an ultra-compact progress section positioned under the action buttons with:
  - Reduced height (h-1 on mobile, h-2 on larger screens)
  - Compact header with inline progress display
  - Single-row stats layout with emoji indicators
  - Better spacing and padding for mobile devices
- **Enhanced mobile responsiveness**: Used responsive classes (sm:) to ensure optimal display across device sizes
- **Improved visual hierarchy**: Added proper background, shadows, and borders for better visual separation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 151`

🔗 [Edit in Builder.io](https://builder.io/app/projects/38a8846cc8a244ed920a34b1c4f7ea86/cosmos-zone)

👀 [Preview Link](https://38a8846cc8a244ed920a34b1c4f7ea86-cosmos-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>38a8846cc8a244ed920a34b1c4f7ea86</projectId>-->
<!--<branchName>cosmos-zone</branchName>-->