### PR TITLE
Remove settings button and mascot from child sidebar

### DIFF
--- a/client/components/ChildProfileSidebar.tsx
+++ b/client/components/ChildProfileSidebar.tsx
@@ -128,8 +128,7 @@ export const ChildProfileSidebar: React.FC<ChildProfileSidebarProps> = ({
                 animate="expanded"
                 exit="collapsed"
                 className="flex-1"
-              >
-              </motion.div>
+              ></motion.div>
             )}
           </AnimatePresence>
 


### PR DESCRIPTION
## Purpose

Clean up the child profile sidebar by removing unnecessary UI elements to improve the layout and prevent scrolling issues. The changes focus on:
- Removing the "⚙️ My Settings" button as requested
- Eliminating the friendly mascot and greeting elements ("Hi there! 🌟 🐻😊 🌅 Good morning! 🌟")
- Ensuring the sidebar fits properly without requiring scrolling while maintaining the notification card layout

## Code changes

- **Removed FriendlyMascot component** with happy mood and speech bubble from sidebar header
- **Deleted time-of-day greeting section** including the gradient background, time info display, and morning greeting
- **Removed Settings button** from both expanded and collapsed sidebar states, including the gear icon and "⚙️ My Settings" text
- **Cleaned up motion.div wrapper** by removing the time-of-day conditional content while preserving the animation structure
- **Maintained logout functionality** and other existing sidebar features

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 176`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b5ad4f839f304e40b7e85abd2f25eb36/zenith-haven)

👀 [Preview Link](https://b5ad4f839f304e40b7e85abd2f25eb36-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b5ad4f839f304e40b7e85abd2f25eb36</projectId>-->
<!--<branchName>zenith-haven</branchName>-->