### PR TITLE
Disable AI enhancement by default in settings

### DIFF
--- a/client/components/EnhancedAISettings.tsx
+++ b/client/components/EnhancedAISettings.tsx
@@ -68,7 +68,7 @@ export interface ExtendedAISettings extends AISettings {
 }
 
 const defaultSettings: ExtendedAISettings = {
-  aiEnhancementEnabled: true,
+  aiEnhancementEnabled: false,
   aiAdaptiveDifficulty: true,
   aiPersonalizedHints: true,
   aiRealTimeAdaptation: true,

--- a/client/lib/aiSettings.ts
+++ b/client/lib/aiSettings.ts
@@ -9,7 +9,7 @@ export interface AISettings {
 export const getAISettings = (): AISettings => {
   return {
     aiEnhancementEnabled: JSON.parse(
-      localStorage.getItem("aiEnhancementEnabled") || "true",
+      localStorage.getItem("aiEnhancementEnabled") || "false",
     ),
     aiAdaptiveDifficulty: JSON.parse(
       localStorage.getItem("aiAdaptiveDifficulty") || "true",


### PR DESCRIPTION
## Purpose
The user requested to make AI navigation/enhancement disabled by default, allowing users to manually enable it from the settings panel if desired. This provides users with more control over AI features and ensures they are opt-in rather than opt-out.

## Code changes
- Changed `aiEnhancementEnabled` default value from `true` to `false` in `EnhancedAISettings.tsx`
- Updated localStorage fallback value from `"true"` to `"false"` in `aiSettings.ts` for the `aiEnhancementEnabled` setting
- AI enhancement features are now disabled by default and require user activation through the settings panel

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 186`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5203b5e674a34b2b917bee13349551a4/zenith-realm)

👀 [Preview Link](https://5203b5e674a34b2b917bee13349551a4-zenith-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5203b5e674a34b2b917bee13349551a4</projectId>-->
<!--<branchName>zenith-realm</branchName>-->