### PR TITLE
Fix dashboard background by changing h-screen to min-h-screen

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -2084,11 +2084,11 @@ export default function Index({ initialProfile }: IndexProps) {
                 style={{ backgroundImage: "url(/images/background.jpg)" }}
               >
                 {/* Enhanced Desktop Layout */}
-                <div className="flex h-screen">
+                <div className="flex min-h-screen">
                   {/* Enhanced Main Game Content Container */}
                   <div className="flex-1 min-w-0 overflow-hidden relative">
                     {/* Game Content Background */}
-                    <div className="relative z-10 w-full h-full p-2 sm:p-3 lg:p-6 pb-20 sm:pb-24 lg:pb-6 overflow-y-auto scroll-smooth">
+                    <div className="relative z-10 w-full min-h-screen p-2 sm:p-3 lg:p-6 pb-20 sm:pb-24 lg:pb-6 overflow-y-auto scroll-smooth">
                       {/* Desktop: Three-column layout with sidebar + main content + side card */}
                       <div className="flex gap-6 items-start">
                         {/* Child Profile Sidebar - Desktop Only */}


### PR DESCRIPTION
## Purpose
Fix the interactive main dashboard background that disappeared by adjusting the height constraints to ensure proper background display across different screen sizes and content lengths.

## Code changes
- Changed `h-screen` to `min-h-screen` on the main flex container to allow content to expand beyond viewport height while maintaining minimum height
- Updated the game content background div from `h-full` to `min-h-screen` to ensure consistent background coverage regardless of content length
- These changes prevent the background from disappearing when content overflows or when the layout doesn't fill the full screen height

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 187`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5203b5e674a34b2b917bee13349551a4/curry-garden)

👀 [Preview Link](https://5203b5e674a34b2b917bee13349551a4-curry-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5203b5e674a34b2b917bee13349551a4</projectId>-->
<!--<branchName>curry-garden</branchName>-->