### PR TITLE
Merge hint and show name buttons into single button

### DIFF
--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -1359,7 +1359,10 @@ export function InteractiveDashboardWordCard({
                 >
                   <Button
                     onClick={() =>
-                      handleActionWithFeedback(() => setShowWordDetails(true), "medium")
+                      handleActionWithFeedback(
+                        () => setShowWordDetails(true),
+                        "medium",
+                      )
                     }
                     size="sm"
                     className="bg-gradient-to-r from-educational-purple via-purple-500 to-purple-600 hover:from-purple-500 hover:via-purple-600 hover:to-purple-700 text-white px-3 py-2 text-xs sm:text-sm rounded-xl min-h-[44px] touch-manipulation group relative overflow-hidden shadow-lg hover:shadow-xl border-2 border-purple-300/50 hover:border-purple-200"
@@ -1367,7 +1370,9 @@ export function InteractiveDashboardWordCard({
                   >
                     <div className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/20 to-white/0 transform -skew-x-12 translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-600 ease-out" />
                     <Eye className="w-4 h-4 mr-1 group-hover:animate-bounce" />
-                    <span className="relative z-10 font-semibold">👁️ Show Name & Hint</span>
+                    <span className="relative z-10 font-semibold">
+                      👁️ Show Name & Hint
+                    </span>
                   </Button>
                 </motion.div>
               )}
@@ -1550,7 +1555,10 @@ export function InteractiveDashboardWordCard({
                         💡 Definition:
                       </h3>
                     </div>
-                    <p className="text-yellow-700 text-sm leading-relaxed" id="hint-text">
+                    <p
+                      className="text-yellow-700 text-sm leading-relaxed"
+                      id="hint-text"
+                    >
                       "{currentWord.definition}"
                     </p>
                     {currentWord.example && (


### PR DESCRIPTION
## Purpose

The user requested to merge the hint button functionality with the show name button functionality to create a single button that displays both the emoji name and hint information together, providing a more streamlined user experience.

## Code changes

- **Removed separate hint button**: Eliminated the dedicated hint button and its associated state (`showHint`)
- **Merged functionality**: Combined hint and show name features into a single "Show Name & Hint" button
- **Unified state management**: Replaced `showWordName` and `showHint` states with a single `showWordDetails` state
- **Updated keyboard shortcuts**: Modified keyboard handlers to use the unified functionality (H/h and S/s keys now trigger the same action)
- **Enhanced display**: When the button is clicked, both the word name and definition/hint are shown together in a single view
- **Improved UI**: Added example text display when available, creating a more comprehensive information panel
- **Updated button label**: Changed button text to "👁️ Show Name & Hint" to reflect the merged functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 191`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d23a86cb0a064549bd6c6dff83c1c6b0/quantum-haven)

👀 [Preview Link](https://d23a86cb0a064549bd6c6dff83c1c6b0-quantum-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d23a86cb0a064549bd6c6dff83c1c6b0</projectId>-->
<!--<branchName>quantum-haven</branchName>-->