### PR TITLE
Add hint display functionality to Get Hint buttons

### DIFF
--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -1407,8 +1407,14 @@ export function InteractiveDashboardWordCard({
                 >
                   {/* Transparent Hint Card */}
                   <motion.div
-                    initial={{ backdropFilter: "blur(0px)", backgroundColor: "rgba(255, 255, 255, 0)" }}
-                    animate={{ backdropFilter: "blur(8px)", backgroundColor: "rgba(255, 255, 255, 0.85)" }}
+                    initial={{
+                      backdropFilter: "blur(0px)",
+                      backgroundColor: "rgba(255, 255, 255, 0)",
+                    }}
+                    animate={{
+                      backdropFilter: "blur(8px)",
+                      backgroundColor: "rgba(255, 255, 255, 0.85)",
+                    }}
                     className="mx-auto max-w-xs p-4 md:p-6 rounded-2xl border-2 border-yellow-300/60 shadow-xl relative overflow-hidden"
                   >
                     {/* Hint background glow */}
@@ -1685,7 +1691,10 @@ export function InteractiveDashboardWordCard({
                     onClick={() => {
                       // Show hint first if not already shown
                       if (!showHint && !showWordDetails) {
-                        handleActionWithFeedback(() => setShowHint(true), "light");
+                        handleActionWithFeedback(
+                          () => setShowHint(true),
+                          "light",
+                        );
                       } else {
                         // If hint is already shown, proceed with main functionality
                         handleWordAction("needs_practice");
@@ -1693,7 +1702,11 @@ export function InteractiveDashboardWordCard({
                     }}
                     disabled={isAnswered}
                     className="w-full bg-gradient-to-r from-red-400 to-pink-500 hover:from-red-500 hover:to-pink-600 active:from-red-600 active:to-pink-700 text-white font-bold border-0 rounded-lg sm:rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105 active:scale-95 py-2 sm:py-3 md:py-4 px-2 sm:px-3 min-h-[48px] sm:min-h-[56px] md:min-h-[64px] relative overflow-hidden disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none touch-manipulation"
-                    aria-label={!showHint && !showWordDetails ? "Get hint for this word" : "Mark word as needing practice"}
+                    aria-label={
+                      !showHint && !showWordDetails
+                        ? "Get hint for this word"
+                        : "Mark word as needing practice"
+                    }
                   >
                     <div className="absolute inset-0 bg-white/20 rounded-xl opacity-0 hover:opacity-100 transition-opacity duration-300"></div>
                     <div className="relative z-10 flex items-center justify-center">
@@ -1702,10 +1715,14 @@ export function InteractiveDashboardWordCard({
                       </span>
                       <div className="text-center">
                         <div className="font-bold text-xs sm:text-sm md:text-base">
-                          {!showHint && !showWordDetails ? "Get Hint" : "Need Practice"}
+                          {!showHint && !showWordDetails
+                            ? "Get Hint"
+                            : "Need Practice"}
                         </div>
                         <div className="text-xs opacity-90 mt-0.5 hidden sm:block">
-                          {!showHint && !showWordDetails ? "Need help? 💡" : "Need practice! 💪"}
+                          {!showHint && !showWordDetails
+                            ? "Need help? 💡"
+                            : "Need practice! 💪"}
                         </div>
                       </div>
                     </div>
@@ -1715,7 +1732,10 @@ export function InteractiveDashboardWordCard({
                     onClick={() => {
                       // Show hint first if not already shown
                       if (!showHint && !showWordDetails) {
-                        handleActionWithFeedback(() => setShowHint(true), "light");
+                        handleActionWithFeedback(
+                          () => setShowHint(true),
+                          "light",
+                        );
                       } else {
                         // If hint is already shown, proceed with main functionality
                         handleWordAction("remembered");
@@ -1723,7 +1743,11 @@ export function InteractiveDashboardWordCard({
                     }}
                     disabled={isAnswered}
                     className="w-full bg-gradient-to-r from-green-400 to-emerald-500 hover:from-green-500 hover:to-emerald-600 active:from-green-600 active:to-emerald-700 text-white font-bold border-0 rounded-lg sm:rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105 active:scale-95 py-2 sm:py-3 md:py-4 px-2 sm:px-3 min-h-[48px] sm:min-h-[56px] md:min-h-[64px] relative overflow-hidden disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none touch-manipulation"
-                    aria-label={!showHint && !showWordDetails ? "Get hint for this word" : "Mark word as remembered"}
+                    aria-label={
+                      !showHint && !showWordDetails
+                        ? "Get hint for this word"
+                        : "Mark word as remembered"
+                    }
                   >
                     <div className="absolute inset-0 bg-white/20 rounded-xl opacity-0 hover:opacity-100 transition-opacity duration-300"></div>
                     <div className="relative z-10 flex items-center justify-center">


### PR DESCRIPTION
## Purpose

The user wanted to enhance the "Get Hint" button functionality by adding a transparent card that displays the emoji name when clicked, while preserving the original button behavior. The goal was to provide users with visual hints to help them guess words more effectively, without disrupting the existing word learning workflow.

## Code changes

- **Added hint display state**: Introduced `showHint` state to control hint visibility
- **Enhanced keyboard support**: Added 'H' key handler to trigger hint display
- **Created transparent hint card**: Implemented animated hint overlay showing emoji name and helpful text
- **Modified button behavior**: Updated both action buttons to show hint first, then perform original actions
- **Added state management**: Integrated hint state resets in word transitions and card resets
- **Removed old show details button**: Cleaned up previous "Show Name & Hint" button implementation
- **Improved accessibility**: Added proper ARIA labels and live regions for hint display

The hint card features smooth animations, floating decorative elements, and maintains the existing button functionality while adding the requested hint preview capability.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 192`

🔗 [Edit in Builder.io](https://builder.io/app/projects/096396b4ab674843bfc6582aace60ddc/nova-nest)

👀 [Preview Link](https://096396b4ab674843bfc6582aace60ddc-nova-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>096396b4ab674843bfc6582aace60ddc</projectId>-->
<!--<branchName>nova-nest</branchName>-->