### PR TITLE
Fix background consistency in Adventure Dashboard

### DIFF
--- a/client/components/AdventureDashboard.tsx
+++ b/client/components/AdventureDashboard.tsx
@@ -245,7 +245,10 @@ export const AdventureDashboard: React.FC<AdventureDashboardProps> = ({
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-pink-50 p-4">
+    <div
+      className="min-h-screen bg-cover bg-center bg-no-repeat p-4"
+      style={{ backgroundImage: "url(/images/background.jpg)" }}
+    >
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Header */}
         <div className="text-center mb-8">


### PR DESCRIPTION
## Purpose
The user noticed that the background styling in the Word Library and Adventure tab didn't match the consistent background used in the main dashboard and quiz sections. This change ensures visual consistency across all application sections.

## Code changes
- Replaced gradient background (`bg-gradient-to-br from-purple-50 via-blue-50 to-pink-50`) with image background in `AdventureDashboard.tsx`
- Added `bg-cover bg-center bg-no-repeat` classes and inline style with `backgroundImage: "url(/images/background.jpg)"`
- This aligns the Adventure Dashboard background with the standard background used throughout the application

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 210`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4156aad595a9409e8f595b95083c870e/flare-space)

👀 [Preview Link](https://4156aad595a9409e8f595b95083c870e-flare-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4156aad595a9409e8f595b95083c870e</projectId>-->
<!--<branchName>flare-space</branchName>-->