### PR TITLE
Fix game element overflow and improve layout visibility

### DIFF
--- a/client/components/games/WordGarden.tsx
+++ b/client/components/games/WordGarden.tsx
@@ -1291,27 +1291,27 @@ export default function WordGarden({
         {/* Jungle path connecting trail */}
         <div className="absolute top-1/2 left-2 right-2 h-1 bg-gradient-to-r from-jungle-dark/40 via-jungle-DEFAULT/60 to-jungle-dark/40 rounded-full -translate-y-1/2 -z-10" />
 
-        {/* Adventure progress indicators */}
-        <div className="absolute -bottom-8 left-0 right-0 flex justify-between text-xs text-gray-600">
-          <div className="text-center">
-            <span className="block">��️</span>
-            <span>Start</span>
+        {/* Adventure progress indicators - repositioned to be visible */}
+        <div className="flex justify-between text-xs text-gray-600 mt-4 px-2">
+          <div className="text-center flex flex-col items-center">
+            <span className="block text-base mb-1">🚀</span>
+            <span className="text-xs font-medium">Start</span>
           </div>
-          <div className="text-center">
-            <span className="block">🌿</span>
-            <span>Jungle</span>
+          <div className="text-center flex flex-col items-center">
+            <span className="block text-base mb-1">🌿</span>
+            <span className="text-xs font-medium">Jungle</span>
           </div>
-          <div className="text-center">
-            <span className="block">🏔️</span>
-            <span>Peak</span>
+          <div className="text-center flex flex-col items-center">
+            <span className="block text-base mb-1">🏔️</span>
+            <span className="text-xs font-medium">Peak</span>
           </div>
-          <div className="text-center">
-            <span className="block">🏆</span>
-            <span>Victory</span>
+          <div className="text-center flex flex-col items-center">
+            <span className="block text-base mb-1">🏆</span>
+            <span className="text-xs font-medium">Victory</span>
           </div>
-          <div className="text-center">
-            <span className="block">👑</span>
-            <span>Legend</span>
+          <div className="text-center flex flex-col items-center">
+            <span className="block text-base mb-1">👑</span>
+            <span className="text-xs font-medium">Legend</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Purpose

The user reported that game elements were overflowing and not visible on the page, specifically the progress indicators showing "🌱 Sprout 🌿 Explorer 🌳 Ranger 👑 Legend" and "🚀 Start 🌿 Jungle 🏔️ Peak 🏆 Victory 👑 Legend". The goal was to optimize the layout to ensure all game elements fit properly within the page boundaries and are fully visible to users.

## Code changes

- **Fixed container layout**: Added bottom padding (`pb-20`) and gradient background to the main game container
- **Repositioned level indicators**: Moved jungle adventure level indicators from absolute positioning to normal flow with proper margins (`mt-3 px-1`)
- **Improved element structure**: Changed progress indicators from horizontal inline layout to vertical flex columns for better space utilization
- **Enhanced spacing**: Added consistent margins (`mb-6`, `mb-8`, `mb-12`) to prevent element overlap
- **Fixed emoji rendering**: Replaced corrupted emoji characters with proper Unicode and improved text sizing
- **Better responsive design**: Used `flex-col items-center` layout for better mobile compatibility and clearer visual hierarchy

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 243`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cd51151f76524a3bbec6048c063038c5/vortex-space)

👀 [Preview Link](https://cd51151f76524a3bbec6048c063038c5-vortex-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cd51151f76524a3bbec6048c063038c5</projectId>-->
<!--<branchName>vortex-space</branchName>-->