### PR TITLE
Fix dialog centering and reduce game container spacing

### DIFF
--- a/client/components/games/WordGarden.tsx
+++ b/client/components/games/WordGarden.tsx
@@ -455,7 +455,8 @@ function JungleGameCompletionDialog({
                   top: `-5%`,
                   width: "1px",
                   height: "110%",
-                  background: "linear-gradient(to bottom, rgba(255, 215, 0, 0.8), rgba(255, 235, 59, 0.4), transparent)",
+                  background:
+                    "linear-gradient(to bottom, rgba(255, 215, 0, 0.8), rgba(255, 235, 59, 0.4), transparent)",
                   transform: `rotate(${-15 + i * 3}deg)`,
                   animationName: "sunlight-shimmer",
                   animationDuration: `${3 + Math.random() * 1.5}s`,
@@ -482,7 +483,11 @@ function JungleGameCompletionDialog({
                 }}
               >
                 <span className="animate-jungle-sway drop-shadow-lg">
-                  {["🌿", "🍃", "🌱", "🌾", "🪴"][Math.floor(Math.random() * 5)]}
+                  {
+                    ["🌿", "🍃", "🌱", "🌾", "🪴"][
+                      Math.floor(Math.random() * 5)
+                    ]
+                  }
                 </span>
               </div>
             ))}
@@ -499,7 +504,8 @@ function JungleGameCompletionDialog({
                   top: "0%",
                   width: "2px",
                   height: "100%",
-                  background: "linear-gradient(to bottom, transparent, rgba(0, 40, 20, 0.9), rgba(0, 60, 30, 0.7))",
+                  background:
+                    "linear-gradient(to bottom, transparent, rgba(0, 40, 20, 0.9), rgba(0, 60, 30, 0.7))",
                   animationName: "vine-sway",
                   animationDuration: `${2.5 + Math.random() * 1.5}s`,
                   animationTimingFunction: "ease-in-out",
@@ -519,7 +525,8 @@ function JungleGameCompletionDialog({
                 style={{
                   left: `${Math.random() * 100}%`,
                   top: `${Math.random() * 100}%`,
-                  background: "radial-gradient(circle, rgba(255, 255, 0, 1), rgba(255, 215, 0, 0.5))",
+                  background:
+                    "radial-gradient(circle, rgba(255, 255, 0, 1), rgba(255, 215, 0, 0.5))",
                   boxShadow: "0 0 6px rgba(255, 255, 0, 0.8)",
                   animationName: "firefly-celebration",
                   animationDuration: `${3 + Math.random() * 2}s`,
@@ -560,11 +567,15 @@ function JungleGameCompletionDialog({
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_70%,rgba(34,197,94,0.2),transparent_60%)]" />
         </div>
         <DialogHeader className="text-center pb-2 relative z-10">
-          <div className="text-6xl mb-3 animate-jungle-celebration drop-shadow-2xl">🏆</div>
+          <div className="text-6xl mb-3 animate-jungle-celebration drop-shadow-2xl">
+            🏆
+          </div>
           <DialogTitle className="text-xl font-bold text-white drop-shadow-2xl bg-emerald-900/70 backdrop-blur-md rounded-lg px-4 py-2 border-2 border-yellow-400/60 shadow-2xl relative">
             {/* Magical glow effect behind text */}
             <div className="absolute inset-0 bg-gradient-to-r from-yellow-400/20 via-yellow-300/30 to-yellow-400/20 rounded-lg blur-sm" />
-            <span className="relative z-10">🏆 🎉 Jungle Quest Complete! 🐒</span>
+            <span className="relative z-10">
+              🏆 🎉 Jungle Quest Complete! 🐒
+            </span>
           </DialogTitle>
           <DialogDescription className="text-emerald-100 text-sm drop-shadow-lg">
             Outstanding adventure! The monkey is so proud! 🍌


### PR DESCRIPTION
## Purpose

The user requested improvements to the Word Garden game UI layout:
- Reduce spacing between level badges and container bottom to make the game more compact
- Fix the "Jungle Quest Complete!" dialog positioning to be properly centered on screen for both desktop and mobile devices

## Code changes

- **Dialog positioning**: Added fixed positioning with `top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2` to center the completion dialog on screen
- **Container spacing**: Reduced bottom padding from `pb-16 md:pb-20` to `pb-6 md:pb-8` in the main game container
- **Progress section spacing**: Decreased margins throughout the progress trail section from `mt-4 md:mt-8 mb-6 md:mb-12` to `mt-2 md:mt-4 mb-2 md:mb-4`
- **Badge spacing**: Reduced margin between XP/streak section and progress badges from `mb-4 md:mb-8` to `mb-1 md:mb-2`
- **Enhanced dialog styling**: Improved the completion dialog with a more immersive jungle background, better visual effects, and enhanced animations

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 253`

🔗 [Edit in Builder.io](https://builder.io/app/projects/abb979a99f2d467385fdca385689c0b9/vortex-hub)

👀 [Preview Link](https://abb979a99f2d467385fdca385689c0b9-vortex-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>abb979a99f2d467385fdca385689c0b9</projectId>-->
<!--<branchName>vortex-hub</branchName>-->