### PR TITLE
Redesign hint card with achievement style and fix audio

### DIFF
--- a/client/components/InteractiveDashboardWordCard.tsx
+++ b/client/components/InteractiveDashboardWordCard.tsx
@@ -1996,13 +1996,15 @@ export function InteractiveDashboardWordCard({
                     }}
                     className="mx-auto max-w-[280px] w-full relative overflow-hidden"
                     style={{
-                      background: "linear-gradient(135deg, #2e7d32 0%, #4caf50 50%, #66bb6a 100%)",
+                      background:
+                        "linear-gradient(135deg, #2e7d32 0%, #4caf50 50%, #66bb6a 100%)",
                       border: "4px solid #ffd700",
                       borderRadius: "20px",
                       padding: "16px 20px",
                       textAlign: "center",
                       color: "white",
-                      fontFamily: '"Comic Sans MS", "Fredoka One", cursive, sans-serif',
+                      fontFamily:
+                        '"Comic Sans MS", "Fredoka One", cursive, sans-serif',
                       boxShadow: `
                         0 10px 30px rgba(0, 0, 0, 0.3),
                         0 0 20px rgba(255, 215, 0, 0.4),
@@ -2012,7 +2014,10 @@ export function InteractiveDashboardWordCard({
                     }}
                   >
                     {/* Achievement-Style Jungle Vines Frame */}
-                    <div className="absolute inset-0 pointer-events-none overflow-hidden" style={{ borderRadius: "20px" }}>
+                    <div
+                      className="absolute inset-0 pointer-events-none overflow-hidden"
+                      style={{ borderRadius: "20px" }}
+                    >
                       {!prefersReducedMotion && (
                         <>
                           <motion.div
@@ -2099,10 +2104,30 @@ export function InteractiveDashboardWordCard({
                       {/* Static vines for reduced motion */}
                       {prefersReducedMotion && (
                         <>
-                          <div className="absolute text-2xl z-1" style={{ top: "-8px", left: "-4px" }}>🌿</div>
-                          <div className="absolute text-2xl z-1" style={{ top: "-8px", right: "-4px" }}>🍃</div>
-                          <div className="absolute text-2xl z-1" style={{ bottom: "-8px", left: "-4px" }}>🌱</div>
-                          <div className="absolute text-2xl z-1" style={{ bottom: "-8px", right: "-4px" }}>🌿</div>
+                          <div
+                            className="absolute text-2xl z-1"
+                            style={{ top: "-8px", left: "-4px" }}
+                          >
+                            🌿
+                          </div>
+                          <div
+                            className="absolute text-2xl z-1"
+                            style={{ top: "-8px", right: "-4px" }}
+                          >
+                            🍃
+                          </div>
+                          <div
+                            className="absolute text-2xl z-1"
+                            style={{ bottom: "-8px", left: "-4px" }}
+                          >
+                            🌱
+                          </div>
+                          <div
+                            className="absolute text-2xl z-1"
+                            style={{ bottom: "-8px", right: "-4px" }}
+                          >
+                            🌿
+                          </div>
                         </>
                       )}
                     </div>
@@ -2187,14 +2212,17 @@ export function InteractiveDashboardWordCard({
                     </motion.button>
 
                     {/* Achievement-Style Soft Glow */}
-                    <div className="absolute inset-0 pointer-events-none" style={{
-                      background: "radial-gradient(circle at center, rgba(255, 215, 0, 0.1) 0%, transparent 70%)",
-                      borderRadius: "20px",
-                    }} />
+                    <div
+                      className="absolute inset-0 pointer-events-none"
+                      style={{
+                        background:
+                          "radial-gradient(circle at center, rgba(255, 215, 0, 0.1) 0%, transparent 70%)",
+                        borderRadius: "20px",
+                      }}
+                    />
 
                     {/* Main Content */}
                     <div className="relative z-2 flex flex-col items-center gap-1">
-
                       {/* Word Display on Green Background */}
                       <motion.div
                         initial={{ opacity: 0, scale: 0.8, y: 20 }}
@@ -2214,7 +2242,8 @@ export function InteractiveDashboardWordCard({
                             style={{
                               fontSize: "1.6rem",
                               color: "white",
-                              textShadow: "0 2px 4px rgba(0, 0, 0, 0.4), 0 3px 8px rgba(46, 125, 50, 0.6), 0 1px 2px rgba(46, 125, 50, 0.8)",
+                              textShadow:
+                                "0 2px 4px rgba(0, 0, 0, 0.4), 0 3px 8px rgba(46, 125, 50, 0.6), 0 1px 2px rgba(46, 125, 50, 0.8)",
                               letterSpacing: "0.05em",
                             }}
                           >
@@ -2234,7 +2263,8 @@ export function InteractiveDashboardWordCard({
                               size="sm"
                               className={cn(
                                 "bg-white/20 hover:bg-white/30 backdrop-blur-sm text-white border border-white/30 hover:border-white/50 p-2 rounded-full transition-all duration-200 transform hover:scale-110 active:scale-95 shadow-lg min-w-[36px] h-9",
-                                isPlaying && "animate-pulse scale-110 bg-white/30",
+                                isPlaying &&
+                                  "animate-pulse scale-110 bg-white/30",
                                 "disabled:opacity-50",
                               )}
                               aria-label="Listen to word pronunciation"


### PR DESCRIPTION
## Purpose

The user requested a complete redesign of the hint card to match the popup container styling with a green background. They wanted to remove the white background and border, eliminate the "💡 Hint!" text, reduce the card size and height, move it up slightly, and ensure the speaker only plays the word once instead of twice.

## Code changes

- **Hint card redesign**: Replaced wooden border style with achievement-style green gradient background (#2e7d32 to #66bb6a) and gold border (#ffd700)
- **Layout improvements**: Removed white background container, reduced padding and margins, moved card up with `-mt-2` class
- **Content simplification**: Removed "💡 Hint!" text and icon, placed word and speaker button directly on green background
- **Visual enhancements**: Added celebration stars (⭐🌟✨) with animations, jungle vine decorations, and achievement-style glow effects
- **Audio fix**: Disabled automatic pronunciation on hint display by commenting out the useEffect hook, ensuring speaker button only plays word once
- **Styling updates**: Applied white text with shadow for better contrast on green background, updated button styling to match new theme
- **Emoji fixes**: Corrected various emoji rendering issues throughout the component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 291`

🔗 [Edit in Builder.io](https://builder.io/app/projects/95ab95bfb6584f7aa4cf9565b7010038/curry-garden)

👀 [Preview Link](https://95ab95bfb6584f7aa4cf9565b7010038-curry-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>95ab95bfb6584f7aa4cf9565b7010038</projectId>-->
<!--<branchName>curry-garden</branchName>-->