### PR TITLE
Improve mobile touch interactions and UI sizing

### DIFF
--- a/client/components/JungleAdventureSettingsPanelV2.tsx
+++ b/client/components/JungleAdventureSettingsPanelV2.tsx
@@ -399,7 +399,12 @@ export default function JungleAdventureSettingsPanelV2({
                         markDirty({ ambient: v as Settings["ambient"] })
                       }
                     >
-                      <SelectTrigger className={cn("w-40", isMobile && "h-10 touch-manipulation")}>
+                      <SelectTrigger
+                        className={cn(
+                          "w-40",
+                          isMobile && "h-10 touch-manipulation",
+                        )}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -424,7 +429,10 @@ export default function JungleAdventureSettingsPanelV2({
                     }
                     max={100}
                     step={5}
-                    className={cn("flex-1", isMobile && "touch-manipulation h-6")}
+                    className={cn(
+                      "flex-1",
+                      isMobile && "touch-manipulation h-6",
+                    )}
                   />
                 </SettingRow>
 
@@ -437,7 +445,12 @@ export default function JungleAdventureSettingsPanelV2({
                         markDirty({ voice: v as Settings["voice"] })
                       }
                     >
-                      <SelectTrigger className={cn("w-40", isMobile && "h-10 touch-manipulation")}>
+                      <SelectTrigger
+                        className={cn(
+                          "w-40",
+                          isMobile && "h-10 touch-manipulation",
+                        )}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -458,7 +471,10 @@ export default function JungleAdventureSettingsPanelV2({
                     step={10}
                     value={[settings.speechRate * 100]}
                     onValueChange={([v]) => markDirty({ speechRate: v / 100 })}
-                    className={cn("flex-1", isMobile && "touch-manipulation h-6")}
+                    className={cn(
+                      "flex-1",
+                      isMobile && "touch-manipulation h-6",
+                    )}
                   />
                 </SettingRow>
 
@@ -495,7 +511,12 @@ export default function JungleAdventureSettingsPanelV2({
                         markDirty({ theme: v as JungleTheme })
                       }
                     >
-                      <SelectTrigger className={cn("w-40", isMobile && "h-10 touch-manipulation")}>
+                      <SelectTrigger
+                        className={cn(
+                          "w-40",
+                          isMobile && "h-10 touch-manipulation",
+                        )}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -621,7 +642,12 @@ export default function JungleAdventureSettingsPanelV2({
                         markDirty({ difficulty: v as Settings["difficulty"] })
                       }
                     >
-                      <SelectTrigger className={cn("w-32", isMobile && "h-10 touch-manipulation")}>
+                      <SelectTrigger
+                        className={cn(
+                          "w-32",
+                          isMobile && "h-10 touch-manipulation",
+                        )}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -640,7 +666,10 @@ export default function JungleAdventureSettingsPanelV2({
                     step={5}
                     value={[settings.dailyGoal]}
                     onValueChange={([v]) => markDirty({ dailyGoal: v })}
-                    className={cn("flex-1", isMobile && "touch-manipulation h-6")}
+                    className={cn(
+                      "flex-1",
+                      isMobile && "touch-manipulation h-6",
+                    )}
                   />
                 </SettingRow>
 
@@ -653,7 +682,10 @@ export default function JungleAdventureSettingsPanelV2({
                     step={5}
                     value={[settings.timeLimitMin]}
                     onValueChange={([v]) => markDirty({ timeLimitMin: v })}
-                    className={cn("flex-1", isMobile && "touch-manipulation h-6")}
+                    className={cn(
+                      "flex-1",
+                      isMobile && "touch-manipulation h-6",
+                    )}
                   />
                 </SettingRow>
 
@@ -686,7 +718,10 @@ export default function JungleAdventureSettingsPanelV2({
                     step={5}
                     value={[settings.textScale * 100]}
                     onValueChange={([v]) => markDirty({ textScale: v / 100 })}
-                    className={cn("flex-1", isMobile && "touch-manipulation h-6")}
+                    className={cn(
+                      "flex-1",
+                      isMobile && "touch-manipulation h-6",
+                    )}
                   />
                 </SettingRow>
 
@@ -809,7 +844,12 @@ function SettingsSection({
 }) {
   if (isMobile) {
     return (
-      <Accordion type="single" collapsible className="w-full" defaultValue={defaultOpen ? "item-1" : undefined}>
+      <Accordion
+        type="single"
+        collapsible
+        className="w-full"
+        defaultValue={defaultOpen ? "item-1" : undefined}
+      >
         <AccordionItem
           value="item-1"
           className="border rounded-lg bg-white/80 backdrop-blur-sm shadow-sm"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -4113,8 +4113,12 @@ export default function Index({ initialProfile }: IndexProps) {
         >
           {/* Subtle Jungle Background Elements */}
           <div className="absolute inset-0 pointer-events-none overflow-hidden rounded-[20px]">
-            <div className="absolute top-3 right-3 text-xl opacity-15 animate-gentle-emoji-float">🌿</div>
-            <div className="absolute bottom-3 left-3 text-lg opacity-12">🍃</div>
+            <div className="absolute top-3 right-3 text-xl opacity-15 animate-gentle-emoji-float">
+              🌿
+            </div>
+            <div className="absolute bottom-3 left-3 text-lg opacity-12">
+              🍃
+            </div>
           </div>
 
           <DialogHeader className="relative z-10 p-6 pb-4">
@@ -4199,9 +4203,7 @@ export default function Index({ initialProfile }: IndexProps) {
                 <div className="absolute inset-0 bg-gradient-to-r from-white/10 to-transparent opacity-0 hover:opacity-100 transition-opacity duration-300" />
                 <div className="relative z-10 flex items-center gap-3 w-full">
                   <div className="relative">
-                    <Settings
-                      className="w-6 h-6 text-white"
-                    />
+                    <Settings className="w-6 h-6 text-white" />
                   </div>
                   <div className="text-left flex-1 min-w-0">
                     <div className="font-semibold text-base sm:text-lg leading-tight">


### PR DESCRIPTION
## Changes Made

### Mobile Touch Enhancements
- Added `touch-manipulation` class to interactive elements (switches, selectors, sliders, buttons)
- Increased button heights from `h-8` to `h-10` for better touch targets
- Scaled up mobile switches with `scale-110` for easier interaction
- Enhanced slider heights to `h-6` on mobile devices

### Layout and Sizing Adjustments
- **Settings Panel**: Increased mobile width from `360px` to `380px`, desktop from `720px` to `800px`
- **Desktop viewport**: Changed from `92vw` to `90vw` width
- **Max heights**: Reduced desktop from `85vh` to `80vh`, adjusted scroll area calculations
- **Grid spacing**: Reduced desktop gap from `4` to `3` for tighter layout
- **Section spacing**: Compressed overlay effects section spacing and icon sizes

### Button and Control Updates
- Increased button padding from `px-3 py-2` to `px-4 py-3`
- Simplified save button text from "Save & Apply" to "Save"
- Enhanced SelectTrigger heights to `h-10` on mobile with touch optimization

### Parent Menu Modal Redesign
- Updated background gradients and styling for cleaner appearance
- Improved button layouts with consistent `rounded-xl` styling
- Enhanced color schemes using jungle/sky theme variables
- Added subtle animations and improved visual hierarchy
- Streamlined button descriptions and removed excessive emoji usage

### Accordion Improvements
- Added `defaultValue` prop for default open state when specified
- Enhanced mobile accordion styling and backdrop effects

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 306`

🔗 [Edit in Builder.io](https://builder.io/app/projects/86967558ca7f4a808033b9db3a9ac332/flare-hub)

👀 [Preview Link](https://86967558ca7f4a808033b9db3a9ac332-flare-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>86967558ca7f4a808033b9db3a9ac332</projectId>-->
<!--<branchName>flare-hub</branchName>-->