### PR TITLE
Update UI components to use dark slate backgrounds

### DIFF
--- a/client/components/EncouragingFeedback.tsx
+++ b/client/components/EncouragingFeedback.tsx
@@ -291,7 +291,7 @@ export function EncouragingFeedback({
                   feedback.onTryAgain?.();
                   onClose();
                 }}
-                className="bg-white/20 hover:bg-white/30 text-white border-white/30 px-4 py-2 text-base"
+                className="bg-slate-800/80 hover:bg-slate-700/90 text-white border-slate-600/50 px-4 py-2 text-base"
                 variant="outline"
               >
                 Try Again 🔄

--- a/client/components/EncouragingFeedback.tsx
+++ b/client/components/EncouragingFeedback.tsx
@@ -268,12 +268,12 @@ export function EncouragingFeedback({
             {(feedback.points || feedback.streak) && (
               <div className="flex justify-center gap-2 flex-wrap">
                 {feedback.points && (
-                  <Badge className="bg-white/30 text-white border-white/30 text-sm py-1 px-3">
+                  <Badge className="bg-slate-800/80 text-white border-slate-600/50 text-sm py-1 px-3">
                     <Zap className="w-3 h-3 mr-1" />+{feedback.points} points
                   </Badge>
                 )}
                 {feedback.streak && (
-                  <Badge className="bg-white/30 text-white border-white/30 text-sm py-1 px-3">
+                  <Badge className="bg-slate-800/80 text-white border-slate-600/50 text-sm py-1 px-3">
                     <Target className="w-3 h-3 mr-1" />
                     {feedback.streak} day streak
                   </Badge>

--- a/client/components/EnhancedVocabularyBuilder.tsx
+++ b/client/components/EnhancedVocabularyBuilder.tsx
@@ -430,7 +430,7 @@ export const EnhancedVocabularyBuilder: React.FC<
               className={`min-h-[48px] px-6 ${
                 accessibilitySettings.highContrast
                   ? "bg-white text-black hover:bg-gray-200"
-                  : "bg-white/20 text-white hover:bg-white/30"
+                  : "bg-slate-800/80 text-white hover:bg-slate-700/90 border border-white/20"
               }`}
               aria-label="Start new session"
             >
@@ -442,7 +442,7 @@ export const EnhancedVocabularyBuilder: React.FC<
               className={`min-h-[48px] px-6 ${
                 accessibilitySettings.highContrast
                   ? "bg-white text-black hover:bg-gray-200"
-                  : "bg-white/20 text-white hover:bg-white/30"
+                  : "bg-slate-800/80 text-white hover:bg-slate-700/90 border border-white/20"
               }`}
               aria-label="Return to word library"
             >

--- a/client/components/JungleAdventureSidebar.tsx
+++ b/client/components/JungleAdventureSidebar.tsx
@@ -375,7 +375,7 @@ export const JungleAdventureSidebar: React.FC<JungleAdventureSidebarProps> = ({
               {userData.name}
             </h2>
             <div className="flex items-center justify-center gap-3 mb-2">
-              <Badge className="bg-white/20 text-white border-white/30 font-['Baloo_2'] text-xs px-3 py-1">
+              <Badge className="bg-navy/80 text-white border-navy/50 font-['Baloo_2'] text-xs px-3 py-1">
                 🌟 Level {userData.level}
               </Badge>
               <Badge className="bg-orange-500/80 text-white border-orange-400/50 font-['Baloo_2'] text-xs px-3 py-1">

--- a/client/global.css
+++ b/client/global.css
@@ -527,19 +527,19 @@
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
 
-    /* Educational color palette for dark mode */
-    --educational-blue: 220 98% 61%;
-    --educational-blue-light: 220 98% 30%;
-    --educational-purple: 282 83% 71%;
-    --educational-purple-light: 282 83% 30%;
-    --educational-green: 142 76% 36%;
-    --educational-green-light: 142 76% 25%;
-    --educational-orange: 25 95% 53%;
-    --educational-orange-light: 25 95% 30%;
-    --educational-pink: 330 81% 60%;
-    --educational-pink-light: 330 81% 30%;
-    --educational-yellow: 48 96% 53%;
-    --educational-yellow-light: 48 96% 30%;
+    /* Educational color palette for dark mode - Unified with jungle theme */
+    --educational-blue: var(--sky-blue);
+    --educational-blue-light: var(--sky-blue-dark);
+    --educational-purple: var(--playful-purple);
+    --educational-purple-light: 291 64% 30%;
+    --educational-green: var(--jungle-green);
+    --educational-green-light: var(--jungle-green-dark);
+    --educational-orange: var(--bright-orange);
+    --educational-orange-light: 30 100% 30%;
+    --educational-pink: var(--coral-red);
+    --educational-pink-light: 14 100% 30%;
+    --educational-yellow: var(--sunshine-yellow);
+    --educational-yellow-light: var(--sunshine-yellow-dark);
   }
 }
 

--- a/client/global.css
+++ b/client/global.css
@@ -1698,7 +1698,7 @@
 
 /* Optimized kid-friendly component classes for smaller screens */
 .kid-card {
-  @apply bg-white/90 backdrop-blur-sm rounded-xl shadow-md border border-purple-200 p-2 lg:p-3 transition-all duration-300 hover:shadow-lg hover:scale-102;
+  @apply bg-white/90 backdrop-blur-sm rounded-xl shadow-md border border-purple-200 p-2 lg:p-3 transition-all duration-300 hover:shadow-lg hover:scale-102 text-slate-800;
 }
 
 .kid-nav-item {

--- a/client/global.css
+++ b/client/global.css
@@ -384,19 +384,19 @@
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
 
-    /* Educational color palette - Enhanced for kids */
-    --educational-blue: 220 98% 61%;
-    --educational-blue-light: 220 98% 85%;
-    --educational-purple: 282 83% 71%;
-    --educational-purple-light: 282 83% 90%;
-    --educational-green: 142 76% 36%;
-    --educational-green-light: 142 76% 85%;
-    --educational-orange: 25 95% 53%;
-    --educational-orange-light: 25 95% 85%;
-    --educational-pink: 330 81% 60%;
-    --educational-pink-light: 330 81% 85%;
-    --educational-yellow: 48 96% 53%;
-    --educational-yellow-light: 48 96% 85%;
+    /* Educational color palette - Now unified with jungle theme */
+    --educational-blue: var(--sky-blue);
+    --educational-blue-light: var(--sky-blue-light);
+    --educational-purple: var(--playful-purple);
+    --educational-purple-light: 291 64% 80%;
+    --educational-green: var(--jungle-green);
+    --educational-green-light: var(--jungle-green-light);
+    --educational-orange: var(--bright-orange);
+    --educational-orange-light: 30 100% 85%;
+    --educational-pink: var(--coral-red);
+    --educational-pink-light: 14 100% 85%;
+    --educational-yellow: var(--sunshine-yellow);
+    --educational-yellow-light: var(--sunshine-yellow-light);
 
     /* Kid-friendly mascot and character colors */
     --mascot-primary: 45 100% 65%; /* Sunny yellow for main mascot */

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -302,11 +302,11 @@
 .treasure-option-card:hover {
   transform: translateY(-12px) scale(1.03);
   box-shadow:
-    0 25px 50px rgba(76, 175, 80, 0.25),
-    0 15px 30px rgba(139, 195, 74, 0.15),
-    0 5px 15px rgba(0, 0, 0, 0.1),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8);
-  border-color: rgba(76, 175, 80, 0.6);
+    0 25px 50px hsl(var(--color-jungle-500) / 0.25),
+    0 15px 30px hsl(var(--color-jungle-400) / 0.15),
+    0 5px 15px hsl(0 0% 0% / 0.1),
+    inset 0 1px 0 hsl(0 0% 100% / 0.8);
+  border-color: hsl(var(--color-jungle-500) / 0.6);
 }
 
 .treasure-option-card:active {

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -333,10 +333,10 @@
 .jungle-treasure-card:hover {
   transform: translateY(-5px) scale(1.02);
   box-shadow:
-    0 30px 60px rgba(76, 175, 80, 0.3),
-    0 15px 35px rgba(139, 195, 74, 0.2),
-    inset 0 2px 0 rgba(255, 255, 255, 0.8),
-    inset 0 -2px 0 rgba(76, 175, 80, 0.2);
+    0 30px 60px var(--quiz-treasure-hover-shadow),
+    0 15px 35px hsl(var(--color-jungle-400) / 0.2),
+    inset 0 2px 0 hsl(0 0% 100% / 0.8),
+    inset 0 -2px 0 hsl(var(--color-jungle-500) / 0.2);
 }
 
 /* ==============================

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -463,7 +463,7 @@
 }
 
 .jungle-progress-trail > div {
-  background: linear-gradient(90deg, #4caf50 0%, #8bc34a 50%, #cddc39 100%);
+  background: var(--quiz-progress-trail);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.3),
     0 0 15px rgba(76, 175, 80, 0.4);
@@ -815,13 +815,13 @@
 }
 
 .high-contrast .treasure-option-card {
-  border: 3px solid #2e7d32;
-  background: rgba(255, 255, 255, 0.95);
+  border: 3px solid var(--quiz-high-contrast-border);
+  background: hsl(0 0% 100% / 0.95);
 }
 
 .high-contrast .jungle-treasure-card {
-  border: 4px solid #1b5e20;
-  background: rgba(255, 255, 255, 0.98);
+  border: 4px solid hsl(var(--quiz-night-start));
+  background: hsl(0 0% 100% / 0.98);
 }
 
 /* ==============================

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -10,21 +10,21 @@
   background:
     radial-gradient(
       circle at 20% 80%,
-      rgba(255, 193, 7, 0.15) 0%,
+      hsl(var(--color-banana-500) / 0.15) 0%,
       transparent 50%
     ),
     radial-gradient(
       circle at 80% 20%,
-      rgba(76, 175, 80, 0.2) 0%,
+      hsl(var(--color-jungle-500) / 0.2) 0%,
       transparent 50%
     ),
     linear-gradient(
       135deg,
-      #e8f5e8 0%,
-      #c8e6c9 25%,
-      #a5d6a7 50%,
-      #81c784 75%,
-      #66bb6a 100%
+      hsl(var(--quiz-morning-start)) 0%,
+      hsl(var(--quiz-morning-mid)) 25%,
+      hsl(var(--quiz-morning-end)) 50%,
+      hsl(var(--color-jungle-300)) 75%,
+      hsl(var(--color-jungle-400)) 100%
     );
   position: relative;
 }

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -33,21 +33,21 @@
   background:
     radial-gradient(
       circle at 30% 70%,
-      rgba(255, 235, 59, 0.2) 0%,
+      hsl(var(--color-banana-500) / 0.2) 0%,
       transparent 50%
     ),
     radial-gradient(
       circle at 70% 30%,
-      rgba(139, 195, 74, 0.25) 0%,
+      hsl(var(--color-jungle-400) / 0.25) 0%,
       transparent 50%
     ),
     linear-gradient(
       135deg,
-      #4caf50 0%,
-      #66bb6a 25%,
-      #81c784 50%,
-      #a5d6a7 75%,
-      #c8e6c9 100%
+      hsl(var(--quiz-midday-start)) 0%,
+      hsl(var(--quiz-midday-mid)) 25%,
+      hsl(var(--quiz-midday-end)) 50%,
+      hsl(var(--color-jungle-200)) 75%,
+      hsl(var(--color-jungle-100)) 100%
     );
 }
 

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -318,16 +318,16 @@
   transition: all 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
   background: linear-gradient(
     135deg,
-    rgba(255, 255, 255, 0.95) 0%,
-    rgba(232, 245, 232, 0.9) 50%,
-    rgba(255, 255, 255, 0.95) 100%
+    hsl(0 0% 100% / 0.95) 0%,
+    hsl(var(--color-jungle-100) / 0.9) 50%,
+    hsl(0 0% 100% / 0.95) 100%
   );
-  border: 3px solid rgba(76, 175, 80, 0.4);
+  border: 3px solid var(--quiz-treasure-border);
   box-shadow:
-    0 20px 40px rgba(76, 175, 80, 0.2),
-    0 10px 25px rgba(139, 195, 74, 0.1),
-    inset 0 2px 0 rgba(255, 255, 255, 0.7),
-    inset 0 -2px 0 rgba(76, 175, 80, 0.1);
+    0 20px 40px var(--quiz-treasure-shadow),
+    0 10px 25px hsl(var(--color-jungle-400) / 0.1),
+    inset 0 2px 0 hsl(0 0% 100% / 0.7),
+    inset 0 -2px 0 hsl(var(--color-jungle-500) / 0.1);
 }
 
 .jungle-treasure-card:hover {

--- a/client/styles/enhanced-jungle-quiz-adventure.css
+++ b/client/styles/enhanced-jungle-quiz-adventure.css
@@ -55,21 +55,21 @@
   background:
     radial-gradient(
       circle at 40% 60%,
-      rgba(255, 152, 0, 0.15) 0%,
+      hsl(var(--color-wood-500) / 0.15) 0%,
       transparent 50%
     ),
     radial-gradient(
       circle at 60% 40%,
-      rgba(56, 142, 60, 0.3) 0%,
+      hsl(var(--quiz-evening-mid) / 0.3) 0%,
       transparent 50%
     ),
     linear-gradient(
       135deg,
-      #2e7d32 0%,
-      #388e3c 25%,
-      #4caf50 50%,
-      #66bb6a 75%,
-      #81c784 100%
+      hsl(var(--quiz-evening-start)) 0%,
+      hsl(var(--quiz-evening-mid)) 25%,
+      hsl(var(--quiz-evening-end)) 50%,
+      hsl(var(--color-jungle-400)) 75%,
+      hsl(var(--color-jungle-300)) 100%
     );
 }
 
@@ -77,21 +77,21 @@
   background:
     radial-gradient(
       circle at 50% 50%,
-      rgba(63, 81, 181, 0.1) 0%,
+      hsl(var(--color-sky-600) / 0.1) 0%,
       transparent 50%
     ),
     radial-gradient(
       circle at 25% 75%,
-      rgba(27, 94, 32, 0.4) 0%,
+      hsl(var(--quiz-night-start) / 0.4) 0%,
       transparent 50%
     ),
     linear-gradient(
       135deg,
-      #1b5e20 0%,
-      #2e7d32 25%,
-      #388e3c 50%,
-      #4caf50 75%,
-      #66bb6a 100%
+      hsl(var(--quiz-night-start)) 0%,
+      hsl(var(--quiz-night-mid)) 25%,
+      hsl(var(--quiz-night-end)) 50%,
+      hsl(var(--color-jungle-500)) 75%,
+      hsl(var(--color-jungle-400)) 100%
     );
 }
 

--- a/client/styles/jungle-design-tokens.css
+++ b/client/styles/jungle-design-tokens.css
@@ -80,6 +80,47 @@
   ); /* Yellow -> Orange warm gradient */
 
   /* ========================================
+   * QUIZ ADVENTURE SYSTEM TOKENS
+   * Replaces hardcoded hex values in quiz CSS
+   * ======================================== */
+
+  /* Time-of-day background themes */
+  --quiz-morning-start: 150 30% 91%; /* #e8f5e8 */
+  --quiz-morning-mid: 122 39% 78%; /* #c8e6c9 */
+  --quiz-morning-end: 122 39% 67%; /* #a5d6a7 */
+
+  --quiz-midday-start: var(--color-jungle-500); /* #4caf50 */
+  --quiz-midday-mid: var(--color-jungle-400); /* #66bb6a */
+  --quiz-midday-end: var(--color-jungle-300); /* #81c784 */
+
+  --quiz-evening-start: 122 39% 20%; /* #2e7d32 */
+  --quiz-evening-mid: 122 42% 39%; /* #388e3c */
+  --quiz-evening-end: var(--color-jungle-500); /* #4caf50 */
+
+  --quiz-night-start: 122 39% 12%; /* #1b5e20 */
+  --quiz-night-mid: 122 39% 20%; /* #2e7d32 */
+  --quiz-night-end: 122 42% 39%; /* #388e3c */
+
+  /* Quiz UI element colors */
+  --quiz-treasure-border: hsl(var(--color-jungle-500) / 0.4);
+  --quiz-treasure-shadow: hsl(var(--color-jungle-500) / 0.2);
+  --quiz-treasure-hover-shadow: hsl(var(--color-jungle-500) / 0.3);
+  --quiz-option-border: hsl(var(--color-jungle-500) / 0.3);
+  --quiz-option-bg: hsl(var(--color-surface) / 0.95);
+  --quiz-gold-accent: 45 100% 50%; /* #ffd700 */
+  --quiz-progress-trail: linear-gradient(
+    90deg,
+    hsl(var(--color-jungle-500)) 0%,
+    hsl(var(--color-jungle-400)) 50%,
+    hsl(var(--color-banana-500)) 100%
+  );
+
+  /* High contrast overrides for accessibility */
+  --quiz-high-contrast-border: var(--quiz-evening-start);
+  --quiz-high-contrast-bg: hsl(0 0% 0%);
+  --quiz-high-contrast-text: hsl(0 0% 100%);
+
+  /* ========================================
    * SURFACE & SEMANTIC COLORS
    * ======================================== */
   --color-bg: 150 28% 98%; /* Main background */

--- a/client/styles/jungle-design-tokens.css
+++ b/client/styles/jungle-design-tokens.css
@@ -515,6 +515,97 @@
 }
 
 /* ========================================
+ * UNIFIED JUNGLE THEME UTILITY CLASSES
+ * ======================================== */
+
+/* Educational color utilities using jungle tokens */
+.bg-educational-primary {
+  background: var(--grad-educational-primary);
+  color: hsl(var(--color-text-inverse));
+}
+
+.bg-educational-success {
+  background: var(--grad-educational-success);
+  color: hsl(var(--color-text-inverse));
+}
+
+.bg-educational-warm {
+  background: var(--grad-educational-warm);
+  color: hsl(var(--color-text-inverse));
+}
+
+.text-educational-primary {
+  color: hsl(var(--educational-blue));
+}
+
+.text-educational-accent {
+  color: hsl(var(--educational-purple));
+}
+
+.text-educational-success {
+  color: hsl(var(--educational-green));
+}
+
+/* Quiz adventure utilities */
+.bg-quiz-morning {
+  background: linear-gradient(
+    135deg,
+    hsl(var(--quiz-morning-start)) 0%,
+    hsl(var(--quiz-morning-mid)) 50%,
+    hsl(var(--quiz-morning-end)) 100%
+  );
+}
+
+.bg-quiz-midday {
+  background: linear-gradient(
+    135deg,
+    hsl(var(--quiz-midday-start)) 0%,
+    hsl(var(--quiz-midday-mid)) 50%,
+    hsl(var(--quiz-midday-end)) 100%
+  );
+}
+
+.bg-quiz-evening {
+  background: linear-gradient(
+    135deg,
+    hsl(var(--quiz-evening-start)) 0%,
+    hsl(var(--quiz-evening-mid)) 50%,
+    hsl(var(--quiz-evening-end)) 100%
+  );
+}
+
+.bg-quiz-night {
+  background: linear-gradient(
+    135deg,
+    hsl(var(--quiz-night-start)) 0%,
+    hsl(var(--quiz-night-mid)) 50%,
+    hsl(var(--quiz-night-end)) 100%
+  );
+}
+
+.quiz-treasure-card {
+  background: var(--quiz-option-bg);
+  border: 3px solid var(--quiz-treasure-border);
+  box-shadow: 0 20px 40px var(--quiz-treasure-shadow);
+  transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+.quiz-treasure-card:hover {
+  box-shadow: 0 30px 60px var(--quiz-treasure-hover-shadow);
+  transform: translateY(-5px) scale(1.02);
+}
+
+.quiz-option-card {
+  background: var(--quiz-option-bg);
+  border: 2px solid var(--quiz-option-border);
+  transition: all 0.3s ease-out;
+}
+
+.quiz-progress-trail {
+  background: var(--quiz-progress-trail);
+}
+
+/* ========================================
  * CONTRAST-SAFE UTILITY CLASSES
  * ======================================== */
 

--- a/client/styles/jungle-design-tokens.css
+++ b/client/styles/jungle-design-tokens.css
@@ -43,6 +43,43 @@
   --color-berry-200: 330 75% 85%; /* Light berry tints */
 
   /* ========================================
+   * EDUCATIONAL SYSTEM UNIFIED MAPPINGS
+   * Maps legacy educational colors to jungle theme
+   * ======================================== */
+  --educational-blue: var(--color-sky-500); /* Primary learning color -> sky blue */
+  --educational-blue-light: var(--color-sky-200); /* Light blue backgrounds */
+  --educational-purple: var(--color-berry-500); /* Secondary learning -> berry purple */
+  --educational-purple-light: var(--color-berry-200); /* Light purple backgrounds */
+  --educational-green: var(--color-jungle-500); /* Success/easy -> jungle green */
+  --educational-green-light: var(--color-jungle-200); /* Light green backgrounds */
+  --educational-yellow: var(--color-banana-500); /* Highlights -> banana yellow */
+  --educational-yellow-light: var(--color-banana-200); /* Light yellow backgrounds */
+  --educational-orange: var(--color-wood-500); /* Medium difficulty -> wood orange */
+  --educational-orange-light: var(--color-wood-200); /* Light orange backgrounds */
+  --educational-pink: var(--color-berry-400); /* Fun accents -> lighter berry */
+  --educational-pink-light: var(--color-berry-200); /* Light pink backgrounds */
+
+  /* Gradient shortcuts for common educational patterns */
+  --grad-educational-primary: linear-gradient(
+    135deg,
+    hsl(var(--color-sky-500)) 0%,
+    hsl(var(--color-berry-500)) 50%,
+    hsl(var(--color-jungle-500)) 100%
+  ); /* Blue -> Purple -> Green hero gradient */
+
+  --grad-educational-success: linear-gradient(
+    135deg,
+    hsl(var(--color-jungle-400)) 0%,
+    hsl(var(--color-jungle-500)) 100%
+  ); /* Green success gradient */
+
+  --grad-educational-warm: linear-gradient(
+    135deg,
+    hsl(var(--color-banana-500)) 0%,
+    hsl(var(--color-wood-500)) 100%
+  ); /* Yellow -> Orange warm gradient */
+
+  /* ========================================
    * SURFACE & SEMANTIC COLORS
    * ======================================== */
   --color-bg: 150 28% 98%; /* Main background */

--- a/client/styles/jungle-design-tokens.css
+++ b/client/styles/jungle-design-tokens.css
@@ -435,3 +435,107 @@
   backface-visibility: hidden;
   perspective: 1000px;
 }
+
+/* ========================================
+ * CONTRAST-SAFE UTILITY CLASSES
+ * ======================================== */
+
+/* Badge utilities with guaranteed contrast */
+.badge-primary {
+  background: hsl(var(--color-jungle-600));
+  color: hsl(var(--color-text-inverse));
+  border: 1px solid hsl(var(--color-jungle-500));
+}
+
+.badge-secondary {
+  background: hsl(var(--color-text-secondary) / 0.8);
+  color: hsl(var(--color-text-inverse));
+  border: 1px solid hsl(var(--color-text-secondary) / 0.6);
+}
+
+.badge-light {
+  background: hsl(var(--color-surface));
+  color: hsl(var(--color-text));
+  border: 1px solid hsl(var(--color-border));
+}
+
+.badge-dark {
+  background: hsl(210 15% 15% / 0.9);
+  color: hsl(var(--color-text-inverse));
+  border: 1px solid hsl(210 15% 25%);
+}
+
+/* Button utilities with proper contrast */
+.btn-overlay-dark {
+  background: hsl(210 15% 15% / 0.8);
+  color: hsl(var(--color-text-inverse));
+  border: 1px solid hsl(210 15% 25% / 0.6);
+}
+
+.btn-overlay-dark:hover {
+  background: hsl(210 15% 10% / 0.9);
+  border-color: hsl(210 15% 30%);
+}
+
+.btn-overlay-light {
+  background: hsl(var(--color-surface) / 0.95);
+  color: hsl(var(--color-text));
+  border: 1px solid hsl(var(--color-border));
+}
+
+.btn-overlay-light:hover {
+  background: hsl(var(--color-surface));
+  border-color: hsl(var(--color-border-light));
+}
+
+/* Card utilities with proper text contrast */
+.card-light {
+  background: hsl(var(--color-surface) / 0.95);
+  color: hsl(var(--color-text));
+  border: 1px solid hsl(var(--color-border));
+}
+
+.card-semi-light {
+  background: hsl(var(--color-surface) / 0.9);
+  color: hsl(var(--color-text));
+  border: 1px solid hsl(var(--color-border) / 0.8);
+}
+
+.card-overlay-dark {
+  background: hsl(210 15% 15% / 0.85);
+  color: hsl(var(--color-text-inverse));
+  border: 1px solid hsl(210 15% 25% / 0.6);
+}
+
+/* Text overlay utilities */
+.text-overlay-dark {
+  color: hsl(var(--color-text-inverse));
+  text-shadow: 0 1px 2px hsl(0 0% 0% / 0.5);
+}
+
+.text-overlay-light {
+  color: hsl(var(--color-text));
+  text-shadow: 0 1px 2px hsl(0 0% 100% / 0.8);
+}
+
+/* High contrast mode overrides */
+@media (prefers-contrast: high) {
+  .badge-primary,
+  .badge-secondary,
+  .badge-dark,
+  .btn-overlay-dark,
+  .card-overlay-dark {
+    background: hsl(0 0% 0%);
+    color: hsl(0 0% 100%);
+    border-color: hsl(0 0% 0%);
+  }
+
+  .badge-light,
+  .btn-overlay-light,
+  .card-light,
+  .card-semi-light {
+    background: hsl(0 0% 100%);
+    color: hsl(0 0% 0%);
+    border-color: hsl(0 0% 0%);
+  }
+}

--- a/client/styles/jungle-design-tokens.css
+++ b/client/styles/jungle-design-tokens.css
@@ -46,16 +46,34 @@
    * EDUCATIONAL SYSTEM UNIFIED MAPPINGS
    * Maps legacy educational colors to jungle theme
    * ======================================== */
-  --educational-blue: var(--color-sky-500); /* Primary learning color -> sky blue */
+  --educational-blue: var(
+    --color-sky-500
+  ); /* Primary learning color -> sky blue */
   --educational-blue-light: var(--color-sky-200); /* Light blue backgrounds */
-  --educational-purple: var(--color-berry-500); /* Secondary learning -> berry purple */
-  --educational-purple-light: var(--color-berry-200); /* Light purple backgrounds */
-  --educational-green: var(--color-jungle-500); /* Success/easy -> jungle green */
-  --educational-green-light: var(--color-jungle-200); /* Light green backgrounds */
-  --educational-yellow: var(--color-banana-500); /* Highlights -> banana yellow */
-  --educational-yellow-light: var(--color-banana-200); /* Light yellow backgrounds */
-  --educational-orange: var(--color-wood-500); /* Medium difficulty -> wood orange */
-  --educational-orange-light: var(--color-wood-200); /* Light orange backgrounds */
+  --educational-purple: var(
+    --color-berry-500
+  ); /* Secondary learning -> berry purple */
+  --educational-purple-light: var(
+    --color-berry-200
+  ); /* Light purple backgrounds */
+  --educational-green: var(
+    --color-jungle-500
+  ); /* Success/easy -> jungle green */
+  --educational-green-light: var(
+    --color-jungle-200
+  ); /* Light green backgrounds */
+  --educational-yellow: var(
+    --color-banana-500
+  ); /* Highlights -> banana yellow */
+  --educational-yellow-light: var(
+    --color-banana-200
+  ); /* Light yellow backgrounds */
+  --educational-orange: var(
+    --color-wood-500
+  ); /* Medium difficulty -> wood orange */
+  --educational-orange-light: var(
+    --color-wood-200
+  ); /* Light orange backgrounds */
   --educational-pink: var(--color-berry-400); /* Fun accents -> lighter berry */
   --educational-pink-light: var(--color-berry-200); /* Light pink backgrounds */
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -159,21 +159,44 @@ export default {
         },
 
         /* ========================================
-         * LEGACY COLORS (deprecated - use new tokens)
+         * EDUCATIONAL COLORS (now unified with jungle theme)
+         * These automatically map to jungle theme tokens via CSS variables
          * ======================================== */
         educational: {
-          blue: "hsl(var(--educational-blue))",
-          "blue-light": "hsl(var(--educational-blue-light))",
-          purple: "hsl(var(--educational-purple))",
-          "purple-light": "hsl(var(--educational-purple-light))",
-          green: "hsl(var(--educational-green))",
-          "green-light": "hsl(var(--educational-green-light))",
-          orange: "hsl(var(--educational-orange))",
-          "orange-light": "hsl(var(--educational-orange-light))",
-          pink: "hsl(var(--educational-pink))",
-          "pink-light": "hsl(var(--educational-pink-light))",
-          yellow: "hsl(var(--educational-yellow))",
-          "yellow-light": "hsl(var(--educational-yellow-light))",
+          blue: "hsl(var(--educational-blue))", /* -> sky-500 */
+          "blue-light": "hsl(var(--educational-blue-light))", /* -> sky-200 */
+          purple: "hsl(var(--educational-purple))", /* -> berry-500 */
+          "purple-light": "hsl(var(--educational-purple-light))", /* -> berry-200 */
+          green: "hsl(var(--educational-green))", /* -> jungle-500 */
+          "green-light": "hsl(var(--educational-green-light))", /* -> jungle-200 */
+          orange: "hsl(var(--educational-orange))", /* -> wood-500 */
+          "orange-light": "hsl(var(--educational-orange-light))", /* -> wood-200 */
+          pink: "hsl(var(--educational-pink))", /* -> berry-400 */
+          "pink-light": "hsl(var(--educational-pink-light))", /* -> berry-200 */
+          yellow: "hsl(var(--educational-yellow))", /* -> banana-500 */
+          "yellow-light": "hsl(var(--educational-yellow-light))", /* -> banana-200 */
+        },
+
+        /* ========================================
+         * QUIZ ADVENTURE THEME COLORS
+         * Time-based backgrounds and quiz UI elements
+         * ======================================== */
+        quiz: {
+          "morning-start": "hsl(var(--quiz-morning-start))",
+          "morning-mid": "hsl(var(--quiz-morning-mid))",
+          "morning-end": "hsl(var(--quiz-morning-end))",
+          "midday-start": "hsl(var(--quiz-midday-start))",
+          "midday-mid": "hsl(var(--quiz-midday-mid))",
+          "midday-end": "hsl(var(--quiz-midday-end))",
+          "evening-start": "hsl(var(--quiz-evening-start))",
+          "evening-mid": "hsl(var(--quiz-evening-mid))",
+          "evening-end": "hsl(var(--quiz-evening-end))",
+          "night-start": "hsl(var(--quiz-night-start))",
+          "night-mid": "hsl(var(--quiz-night-mid))",
+          "night-end": "hsl(var(--quiz-night-end))",
+          "gold": "hsl(var(--quiz-gold-accent))",
+          "treasure-border": "var(--quiz-treasure-border)",
+          "option-bg": "var(--quiz-option-bg)",
         },
         // Legacy Jungle Green Family
         "jungle-legacy": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -163,18 +163,22 @@ export default {
          * These automatically map to jungle theme tokens via CSS variables
          * ======================================== */
         educational: {
-          blue: "hsl(var(--educational-blue))", /* -> sky-500 */
-          "blue-light": "hsl(var(--educational-blue-light))", /* -> sky-200 */
-          purple: "hsl(var(--educational-purple))", /* -> berry-500 */
-          "purple-light": "hsl(var(--educational-purple-light))", /* -> berry-200 */
-          green: "hsl(var(--educational-green))", /* -> jungle-500 */
-          "green-light": "hsl(var(--educational-green-light))", /* -> jungle-200 */
-          orange: "hsl(var(--educational-orange))", /* -> wood-500 */
-          "orange-light": "hsl(var(--educational-orange-light))", /* -> wood-200 */
-          pink: "hsl(var(--educational-pink))", /* -> berry-400 */
-          "pink-light": "hsl(var(--educational-pink-light))", /* -> berry-200 */
-          yellow: "hsl(var(--educational-yellow))", /* -> banana-500 */
-          "yellow-light": "hsl(var(--educational-yellow-light))", /* -> banana-200 */
+          blue: "hsl(var(--educational-blue))" /* -> sky-500 */,
+          "blue-light": "hsl(var(--educational-blue-light))" /* -> sky-200 */,
+          purple: "hsl(var(--educational-purple))" /* -> berry-500 */,
+          "purple-light":
+            "hsl(var(--educational-purple-light))" /* -> berry-200 */,
+          green: "hsl(var(--educational-green))" /* -> jungle-500 */,
+          "green-light":
+            "hsl(var(--educational-green-light))" /* -> jungle-200 */,
+          orange: "hsl(var(--educational-orange))" /* -> wood-500 */,
+          "orange-light":
+            "hsl(var(--educational-orange-light))" /* -> wood-200 */,
+          pink: "hsl(var(--educational-pink))" /* -> berry-400 */,
+          "pink-light": "hsl(var(--educational-pink-light))" /* -> berry-200 */,
+          yellow: "hsl(var(--educational-yellow))" /* -> banana-500 */,
+          "yellow-light":
+            "hsl(var(--educational-yellow-light))" /* -> banana-200 */,
         },
 
         /* ========================================
@@ -194,7 +198,7 @@ export default {
           "night-start": "hsl(var(--quiz-night-start))",
           "night-mid": "hsl(var(--quiz-night-mid))",
           "night-end": "hsl(var(--quiz-night-end))",
-          "gold": "hsl(var(--quiz-gold-accent))",
+          gold: "hsl(var(--quiz-gold-accent))",
           "treasure-border": "var(--quiz-treasure-border)",
           "option-bg": "var(--quiz-option-bg)",
         },


### PR DESCRIPTION
## Changes Made

### Component Background Updates
- **EncouragingFeedback.tsx**: Updated badge and button backgrounds from `bg-white/30` to `bg-slate-800/80` with matching border colors
- **EnhancedVocabularyBuilder.tsx**: Changed button backgrounds from `bg-white/20` to `bg-slate-800/80` for non-high-contrast mode
- **JungleAdventureSidebar.tsx**: Updated level badge background from `bg-white/20` to `bg-navy/80`

### CSS Theme System Improvements
- **global.css**: 
  - Unified educational color palette to use jungle theme tokens instead of hardcoded values
  - Added text color (`text-slate-800`) to `.kid-card` class for better contrast
  - Updated both light and dark mode educational color mappings

- **enhanced-jungle-quiz-adventure.css**:
  - Replaced hardcoded hex colors with HSL color tokens for quiz backgrounds
  - Added comprehensive quiz adventure theme color system with time-of-day variants
  - Added utility classes for badges, buttons, and cards with proper contrast ratios
  - Included high contrast mode overrides for accessibility

- **tailwind.config.ts**:
  - Added new `quiz` color palette with time-based background variants
  - Updated educational colors to map to unified jungle theme tokens
  - Added quiz-specific utility colors for treasure borders and option backgrounds

### Visual Impact
These changes provide more consistent, darker overlay backgrounds that improve readability while maintaining the jungle adventure theme aesthetic.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 325`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9ef7d83d50da4ed1805f1f31b44a2a78/swoosh-sanctuary)

👀 [Preview Link](https://9ef7d83d50da4ed1805f1f31b44a2a78-swoosh-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9ef7d83d50da4ed1805f1f31b44a2a78</projectId>-->
<!--<branchName>swoosh-sanctuary</branchName>-->