### PR TITLE
Redesign profile section with premium styling and layout

### DIFF
--- a/client/components/JungleAdventureSidebar.tsx
+++ b/client/components/JungleAdventureSidebar.tsx
@@ -336,16 +336,18 @@ export const JungleAdventureSidebar: React.FC<JungleAdventureSidebarProps> = ({
           variants={{
             initial: {
               scale: 1,
-              boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)"
+              boxShadow:
+                "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
             },
             hover: {
               scale: 1.02,
-              boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+              boxShadow:
+                "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
               transition: {
                 duration: 0.3,
-                ease: "easeOut"
-              }
-            }
+                ease: "easeOut",
+              },
+            },
           }}
         >
           {/* Premium gradient overlay on hover */}
@@ -367,12 +369,18 @@ export const JungleAdventureSidebar: React.FC<JungleAdventureSidebarProps> = ({
               transition={{ duration: 0.5, type: "spring", stiffness: 300 }}
             >
               <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-jungle to-jungle-dark flex items-center justify-center shadow-lg relative">
-                <span className="text-2xl text-white">{userData.avatar?.emoji || "🎯"}</span>
+                <span className="text-2xl text-white">
+                  {userData.avatar?.emoji || "🎯"}
+                </span>
                 {/* Level indicator ring */}
                 <motion.div
                   className="absolute -top-2 -right-2 w-6 h-6 bg-sunshine rounded-full flex items-center justify-center shadow-lg border-2 border-white"
                   animate={{ rotate: 360 }}
-                  transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
+                  transition={{
+                    duration: 15,
+                    repeat: Infinity,
+                    ease: "linear",
+                  }}
                 >
                   <span className="text-navy text-[10px] font-bold">
                     {userData.level}


### PR DESCRIPTION
## Purpose
The user requested to enhance the profile section in the Jungle Adventure sidebar by:
- Applying consistent card styling to match other sections (Words Learned and Learning Streak)
- Removing the view profile icon and optimizing content layout
- Making the profile section slightly bigger with improved visual hierarchy
- Adding premium hover effects for better user interaction

## Code changes
- **Background styling**: Changed from purple gradient to clean white/glass design with backdrop blur
- **Layout restructure**: Reorganized content with emoji at top, user name, explorer status, then badges at bottom
- **Premium hover effects**: Added scale animation and enhanced shadow effects on hover
- **Visual enhancements**: 
  - Replaced large badges with smaller, rounded badge pills
  - Added subtle animated particles that appear on hover
  - Improved avatar styling with jungle gradient background
  - Enhanced typography and spacing for better readability
- **Responsive design**: Optimized content fitting and improved visual hierarchy

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 326`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6a57ac414f614450a990cb87a5f4dd68/zenith-hub)

👀 [Preview Link](https://6a57ac414f614450a990cb87a5f4dd68-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6a57ac414f614450a990cb87a5f4dd68</projectId>-->
<!--<branchName>zenith-hub</branchName>-->