### PR TITLE
Upgrade JungleAdventureWordCard with Ultimate features

### DIFF
--- a/client/components/JungleAdventureWordCard.tsx
+++ b/client/components/JungleAdventureWordCard.tsx
@@ -121,7 +121,9 @@ export const JungleAdventureWordCard: React.FC<
   >([]);
   const [currentAnimation, setCurrentAnimation] = useState("");
   // Ultimate-mode integrations
-  const [discoveryMode, setDiscoveryMode] = useState<"learn" | "quiz" | "memory">("learn");
+  const [discoveryMode, setDiscoveryMode] = useState<
+    "learn" | "quiz" | "memory"
+  >("learn");
   const [quizRevealed, setQuizRevealed] = useState<boolean>(showDefinition);
   const [score, setScore] = useState<number>(0);
 
@@ -590,7 +592,9 @@ export const JungleAdventureWordCard: React.FC<
             variant={discoveryMode === mode ? "default" : "outline"}
             className={cn(
               "min-h-[44px] px-3 font-bold",
-              discoveryMode === mode ? "bg-jungle text-white shadow-lg scale-105" : "bg-white/70 text-gray-700 hover:bg-white/80",
+              discoveryMode === mode
+                ? "bg-jungle text-white shadow-lg scale-105"
+                : "bg-white/70 text-gray-700 hover:bg-white/80",
             )}
           >
             {mode === "learn" && "📖 Learn"}
@@ -768,14 +772,19 @@ export const JungleAdventureWordCard: React.FC<
               <div className="text-center space-y-1 sm:space-y-2">
                 <div className="flex items-center justify-center gap-2 sm:gap-3">
                   <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-5xl font-bold tracking-wide drop-shadow-2xl leading-tight jungle-adventure-word text-center">
-                    {(discoveryMode === "quiz" || discoveryMode === "memory") && !quizRevealed ? "???" : word.word}
+                    {(discoveryMode === "quiz" || discoveryMode === "memory") &&
+                    !quizRevealed
+                      ? "???"
+                      : word.word}
                   </h2>
                   <Button
                     onClick={(e) => {
                       e.stopPropagation();
                       handlePronounce();
                     }}
-                    disabled={isPlaying || (discoveryMode !== "learn" && !quizRevealed)}
+                    disabled={
+                      isPlaying || (discoveryMode !== "learn" && !quizRevealed)
+                    }
                     className={cn(
                       "h-12 w-12 sm:h-14 sm:w-14 rounded-full transition-all duration-300 flex-shrink-0",
                       "bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600",

--- a/client/components/JungleAdventureWordCard.tsx
+++ b/client/components/JungleAdventureWordCard.tsx
@@ -120,6 +120,10 @@ export const JungleAdventureWordCard: React.FC<
     Array<{ id: number; emoji: string; x: number; y: number; delay: number }>
   >([]);
   const [currentAnimation, setCurrentAnimation] = useState("");
+  // Ultimate-mode integrations
+  const [discoveryMode, setDiscoveryMode] = useState<"learn" | "quiz" | "memory">("learn");
+  const [quizRevealed, setQuizRevealed] = useState<boolean>(showDefinition);
+  const [score, setScore] = useState<number>(0);
 
   const isMastered = isWordMastered?.(word.id) || false;
   const isFavorited = isWordFavorited?.(word.id) || false;
@@ -157,6 +161,20 @@ export const JungleAdventureWordCard: React.FC<
     setTimeout(() => setParticles([]), 2000);
   };
 
+  // Scoring + progression dispatcher
+  const updateScore = (delta: number, reason: string) => {
+    setScore((prev) => {
+      const next = prev + delta;
+      try {
+        const event = new CustomEvent("wordProgressUpdate", {
+          detail: { wordId: word.id, delta, reason, score: next },
+        });
+        window.dispatchEvent(event);
+      } catch {}
+      return next;
+    });
+  };
+
   // Jungle adventure effects - much lighter
   useEffect(() => {
     const interval = setInterval(() => {
@@ -165,6 +183,11 @@ export const JungleAdventureWordCard: React.FC<
     }, 15000); // Reduced frequency from 8000ms
     return () => clearInterval(interval);
   }, []);
+
+  // Reset reveal state when word or mode changes
+  useEffect(() => {
+    setQuizRevealed(discoveryMode !== "quiz");
+  }, [word.id, discoveryMode]);
 
   // Enhanced pronunciation with jungle sounds
   const handlePronounce = async () => {
@@ -222,6 +245,14 @@ export const JungleAdventureWordCard: React.FC<
     // Auto-pronounce on tap if enabled
     if (!isFlipped) {
       handlePronounce();
+    }
+
+    // Scoring for taps + quiz reveal
+    updateScore(5, "tap");
+    if (discoveryMode === "quiz" && !quizRevealed) {
+      setQuizRevealed(true);
+      createParticles();
+      updateScore(10, "quiz_reveal");
     }
 
     setIsFlipped(!isFlipped);
@@ -318,6 +349,9 @@ export const JungleAdventureWordCard: React.FC<
   const handleMastery = (rating: "easy" | "medium" | "hard") => {
     setRatedAs(rating);
     setShowCelebration(true);
+    if (rating === "easy") {
+      updateScore(25, "mastery");
+    }
 
     // Only show particles for "easy" rating (mastered)
     if (rating === "easy") {
@@ -378,6 +412,8 @@ export const JungleAdventureWordCard: React.FC<
       onWordFavorite(word.id);
     }
     audioService.playSound?.(isFavorited ? "click" : "sparkle");
+    createParticles();
+    updateScore(15, "favorite");
 
     // Haptic feedback
     if (navigator.vibrate) {
@@ -532,6 +568,37 @@ export const JungleAdventureWordCard: React.FC<
           </div>
         </div>
       )}
+
+      {/* Header Stats */}
+      <div className="flex justify-between items-center mb-3 bg-white/90 backdrop-blur-sm rounded-2xl p-3 shadow-lg">
+        <div className="flex items-center gap-2">
+          <span className="text-2xl">🏆</span>
+          <span className="font-bold text-gray-800">{score} Points</span>
+        </div>
+        <div className="text-xs text-gray-600">Mode: {discoveryMode}</div>
+      </div>
+
+      {/* Mode Selector */}
+      <div className="flex justify-center gap-2 mb-4">
+        {(["learn", "quiz", "memory"] as const).map((mode) => (
+          <Button
+            key={mode}
+            onClick={() => {
+              setDiscoveryMode(mode);
+              setQuizRevealed(mode !== "quiz");
+            }}
+            variant={discoveryMode === mode ? "default" : "outline"}
+            className={cn(
+              "min-h-[44px] px-3 font-bold",
+              discoveryMode === mode ? "bg-jungle text-white shadow-lg scale-105" : "bg-white/70 text-gray-700 hover:bg-white/80",
+            )}
+          >
+            {mode === "learn" && "📖 Learn"}
+            {mode === "quiz" && "🎯 Quiz"}
+            {mode === "memory" && "🧠 Memory"}
+          </Button>
+        ))}
+      </div>
 
       {/* 3D Jungle Adventure Card */}
       <div
@@ -701,14 +768,14 @@ export const JungleAdventureWordCard: React.FC<
               <div className="text-center space-y-1 sm:space-y-2">
                 <div className="flex items-center justify-center gap-2 sm:gap-3">
                   <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-5xl font-bold tracking-wide drop-shadow-2xl leading-tight jungle-adventure-word text-center">
-                    {word.word}
+                    {(discoveryMode === "quiz" || discoveryMode === "memory") && !quizRevealed ? "???" : word.word}
                   </h2>
                   <Button
                     onClick={(e) => {
                       e.stopPropagation();
                       handlePronounce();
                     }}
-                    disabled={isPlaying}
+                    disabled={isPlaying || (discoveryMode !== "learn" && !quizRevealed)}
                     className={cn(
                       "h-12 w-12 sm:h-14 sm:w-14 rounded-full transition-all duration-300 flex-shrink-0",
                       "bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600",

--- a/client/components/LearningDashboard.tsx
+++ b/client/components/LearningDashboard.tsx
@@ -25,7 +25,6 @@ import {
   CheckCircle,
   AlertCircle,
 } from "lucide-react";
-import { UltimateDemoSection } from "./UltimateDemoSection";
 
 interface LearningStats {
   wordsLearned: number;
@@ -189,8 +188,6 @@ export const LearningDashboard: React.FC<LearningDashboardProps> = ({
 
   return (
     <div className="space-y-4">
-      {/* Ultimate Demo Section */}
-      <UltimateDemoSection />
       {/* Interactive Word Learning Hub - PRIMARY FEATURE */}
       {availableWords.length > 0 && onWordProgress ? (
         <>

--- a/client/pages/WordAdventureDemo.tsx
+++ b/client/pages/WordAdventureDemo.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, RefreshCw, Shuffle, Grid3X3 } from "lucide-react";
-import { EnhancedWordAdventureCard } from "@/components/EnhancedWordAdventureCard";
+import { JungleAdventureWordCard } from "@/components/JungleAdventureWordCard";
 import {
   wordsDatabase,
   getWordsByCategory,
@@ -179,12 +179,11 @@ export function WordAdventureDemo() {
         {/* Word Card Display */}
         {currentWord ? (
           <div className="flex justify-center">
-            <EnhancedWordAdventureCard
+            <JungleAdventureWordCard
               word={currentWord}
-              onFavorite={handleWordFavorite}
+              onWordFavorite={(id) => handleWordFavorite(currentWord)}
               onWordMastered={handleWordMastered}
               showVocabularyBuilder={true}
-              enableMiniGames={true}
               autoPlay={false}
               className="animate-fade-in"
             />


### PR DESCRIPTION
## Purpose

This PR implements the user's request to upgrade JungleAdventureWordCard with Ultimate Word Card features while cleaning up the Interactive Dashboard. The goal was to:

- Integrate multi-mode learning (Learn, Quiz, Memory) into the jungle adventure experience
- Add gamification scoring system with particle celebrations
- Remove UltimateWordCardDemo from the main dashboard navigation
- Keep the adventure progression and jungle theming intact

## Code Changes

### JungleAdventureWordCard.tsx
- **Added Ultimate features**: Multi-mode learning with Learn/Quiz/Memory modes
- **Scoring system**: Points for taps (+5), quiz reveals (+10), favorites (+15), and mastery (+25)
- **Mode selector**: Interactive buttons to switch between learning modes
- **Quiz functionality**: Hidden word/definition until revealed in quiz mode
- **Header stats**: Display current score and active mode
- **Enhanced interactions**: Particle effects and score updates for user actions

### LearningDashboard.tsx
- **Removed UltimateDemoSection**: Cleaned up dashboard by removing Ultimate demo card and navigation

### WordAdventureDemo.tsx
- **Component swap**: Replaced EnhancedWordAdventureCard with upgraded JungleAdventureWordCard
- **Props alignment**: Updated component props to match new interface

The changes successfully integrate Ultimate Word Card functionality into the jungle adventure experience while maintaining the existing adventure progression system and removing demo components from the main dashboard navigation.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 335`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a04c48d4dfae4dfab5496d52e385b1ad/zenith-field)

👀 [Preview Link](https://a04c48d4dfae4dfab5496d52e385b1ad-zenith-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a04c48d4dfae4dfab5496d52e385b1ad</projectId>-->
<!--<branchName>zenith-field</branchName>-->