### PR TITLE
Fix mobile layout and progress bar visibility issues

### DIFF
--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -509,6 +509,7 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
                     ageGroup={ageGroup}
                     showDifficulty={ageGroup !== "3-5"}
                     tileSize={ageGroup === "3-5" ? "lg" : "md"}
+                    progress={progress}
                   />
                 </motion.div>
               )}

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -54,7 +54,7 @@ const JUNGLE_CATEGORIES: Omit<Category, "wordCount" | "masteredCount">[] = [
   {
     id: "colors",
     name: "Colors",
-    emoji: "🌈",
+    emoji: "����",
     description: "Learn about the beautiful colors around us!",
     estimatedTime: "2-5 min",
   },
@@ -715,10 +715,19 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           <JungleAdventureIconNav
             activeId="jungle"
             onNavigate={(id) => {
-              if (id === "home") navigate("/app");
-              else if (id === "jungle") navigate("/jungle-word-explorer");
-              else if (id === "quiz") navigate("/app");
-              else if (id === "trophy") navigate("/app");
+              if (id === "home") {
+                navigate("/app");
+              } else if (id === "jungle") {
+                setMode("map");
+                setSelectedCategory(null);
+                setCurrentWords([]);
+                setCurrentWordIndex(0);
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              } else if (id === "quiz") {
+                handleModeChange("adventure");
+              } else if (id === "trophy") {
+                setMode("favorites");
+              }
             }}
           />
         </ExplorerShell>

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -484,7 +484,7 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           selectedCategory={selectedCategory}
         >
           {/* Main Content Area */}
-          <div className="max-w-7xl mx-auto px-4 py-6 pb-40 md:pb-44 lg:pb-48 safe-area-padding-bottom">
+          <div className="max-w-7xl mx-auto px-4 py-6 pb-6 md:pb-8 lg:pb-10 safe-area-padding-bottom">
             <AnimatePresence mode="wait">
               {/* Map Mode - Category Grid */}
               {mode === "map" && (

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -484,7 +484,7 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           selectedCategory={selectedCategory}
         >
           {/* Main Content Area */}
-          <div className="max-w-7xl mx-auto px-4 py-6 pb-28 md:pb-32 lg:pb-36 safe-area-padding-bottom">
+          <div className="max-w-7xl mx-auto px-4 py-6 pb-40 md:pb-44 lg:pb-48 safe-area-padding-bottom">
             <AnimatePresence mode="wait">
               {/* Map Mode - Category Grid */}
               {mode === "map" && (

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -715,16 +715,14 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           <JungleAdventureIconNav
             activeId="jungle"
             onNavigate={(id) => {
-              if (id === "home" || id === "jungle") {
-                setMode("map");
-                setSelectedCategory(null);
-                setCurrentWords([]);
-                setCurrentWordIndex(0);
-                window.scrollTo({ top: 0, behavior: "smooth" });
+              if (id === "home") {
+                navigate("/app?tab=dashboard");
+              } else if (id === "jungle") {
+                navigate("/jungle-word-explorer");
               } else if (id === "quiz") {
-                handleModeChange("adventure");
+                navigate("/app?tab=quiz");
               } else if (id === "trophy") {
-                setMode("favorites");
+                navigate("/app?tab=achievements");
               }
             }}
           />

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -95,6 +95,8 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
   ageGroup = "6-8",
   accessibilitySettings = {},
 }) => {
+  const navigate = useNavigate();
+
   const [mode, setMode] = useState<"map" | "adventure" | "favorites">(
     initialMode,
   );

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -54,7 +54,7 @@ const JUNGLE_CATEGORIES: Omit<Category, "wordCount" | "masteredCount">[] = [
   {
     id: "colors",
     name: "Colors",
-    emoji: "����",
+    emoji: "🌈",
     description: "Learn about the beautiful colors around us!",
     estimatedTime: "2-5 min",
   },
@@ -715,9 +715,7 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           <JungleAdventureIconNav
             activeId="jungle"
             onNavigate={(id) => {
-              if (id === "home") {
-                navigate("/app");
-              } else if (id === "jungle") {
+              if (id === "home" || id === "jungle") {
                 setMode("map");
                 setSelectedCategory(null);
                 setCurrentWords([]);

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -461,7 +461,6 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           gems={sessionStats.gems}
           streak={sessionStats.streak}
           sessionTime={sessionStats.sessionTime}
-          progress={progress}
           audioEnabled={effectiveSettings.audioEnabled}
           onAudioToggle={() => setAudioEnabled(!audioEnabled)}
           highContrast={effectiveSettings.highContrast}

--- a/client/components/JungleWordLibrary.tsx
+++ b/client/components/JungleWordLibrary.tsx
@@ -484,7 +484,7 @@ export const JungleWordLibrary: React.FC<JungleWordLibraryProps> = ({
           selectedCategory={selectedCategory}
         >
           {/* Main Content Area */}
-          <div className="max-w-7xl mx-auto px-4 py-6">
+          <div className="max-w-7xl mx-auto px-4 py-6 pb-28 md:pb-32 lg:pb-36 safe-area-padding-bottom">
             <AnimatePresence mode="wait">
               {/* Map Mode - Category Grid */}
               {mode === "map" && (

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -319,7 +319,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
           {/* Filter Buttons */}
           {showFilters && (
-            <div className="flex flex-wrap items-center gap-2 justify-start">
+            <div className="flex flex-nowrap items-center gap-1 md:gap-2 justify-start overflow-x-auto whitespace-nowrap">
               {filterButtons.map(({ key, label, icon }) => {
                 const count = getFilterCounts[key];
                 const isActive = activeFilter === key;
@@ -333,7 +333,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                     variant={isActive ? "default" : "outline"}
                     size="sm"
                     className={cn(
-                      "rounded-full transition-all duration-200",
+                      "rounded-full transition-all duration-200 shrink-0",
                       isActive && "shadow-md scale-105",
                       key === "all" && "order-1",
                       key === "recommended" && "order-2",
@@ -364,7 +364,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                   onClick={handleClearFilters}
                   variant="outline"
                   size="sm"
-                  className="rounded-full order-3 md:order-none ml-1"
+                  className="rounded-full order-3 md:order-none ml-1 shrink-0"
                   aria-label="Clear all filters"
                 >
                   <RotateCcw className="w-3 h-3 mr-1" />

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -494,7 +494,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
-        <div className="jungle-progress-container p-2 sm:p-4 -mt-1 sm:mt-0 mb-2 overflow-visible">
+        <div className="jungle-progress-container p-2 sm:p-4 -mt-2 sm:mt-0 mb-3 overflow-visible">
           {/* Jungle quick stats - playful badges */}
           <div className="grid grid-cols-3 gap-1 sm:gap-3 jungle-achievements-grid">
             <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -497,20 +497,20 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
         <div className="mt-4">
           {/* Jungle quick stats - playful badges */}
           <div className="flex flex-wrap justify-center gap-2 sm:gap-3 text-xs sm:text-sm">
-            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-50/80 text-green-800 border border-green-200 shadow-sm" aria-label={`${getFilterCounts.completed} completed categories`}>
+            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-emerald-600 text-white border border-emerald-700 shadow-sm" aria-label={`${getFilterCounts.completed} completed categories`}>
               <span>🌿</span>
               <span className="font-semibold">{getFilterCounts.completed}</span>
-              <span className="opacity-80">completed</span>
+              <span className="font-medium">completed</span>
             </span>
-            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-sky-50/80 text-sky-800 border border-sky-200 shadow-sm" aria-label={`${getFilterCounts["in-progress"]} in progress categories`}>
+            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-sky-600 text-white border border-sky-700 shadow-sm" aria-label={`${getFilterCounts["in-progress"]} in progress categories`}>
               <span>🧭</span>
               <span className="font-semibold">{getFilterCounts["in-progress"]}</span>
-              <span className="opacity-80">in progress</span>
+              <span className="font-medium">in progress</span>
             </span>
-            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-50/80 text-yellow-900 border border-yellow-200 shadow-sm" aria-label={`${getFilterCounts.recommended} recommended categories`}>
+            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-500 text-white border border-yellow-600 shadow-sm" aria-label={`${getFilterCounts.recommended} recommended categories`}>
               <span>⭐</span>
               <span className="font-semibold">{getFilterCounts.recommended}</span>
-              <span className="opacity-80">recommended</span>
+              <span className="font-medium">recommended</span>
             </span>
           </div>
 

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -494,7 +494,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
-        <div className="mt-6 pt-4 border-t border-gray-200">
+        <div className="mt-4">
           {/* Jungle quick stats - playful badges */}
           <div className="flex flex-wrap justify-center gap-2 sm:gap-3 text-xs sm:text-sm">
             <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-50/80 text-green-800 border border-green-200 shadow-sm" aria-label={`${getFilterCounts.completed} completed categories`}>
@@ -521,7 +521,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                 <span className="text-sm sm:text-base font-semibold text-emerald-800 flex items-center gap-1">
                   <span className="select-none">🌿</span> Learning Journey
                 </span>
-                <span className="text-xs sm:text-sm text-emerald-900 bg-white/60 border border-white/40 rounded-full px-2 py-0.5">
+                <span className="text-xs sm:text-sm text-emerald-900">
                   {progress.current} of {progress.total} completed
                 </span>
               </div>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -500,25 +500,52 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
         <div className="jungle-progress-container p-2 sm:p-4 -mt-4 sm:mt-0 mb-4 overflow-visible relative z-10">
           {/* Jungle quick stats - playful badges */}
           <div className="grid grid-cols-3 gap-1 sm:gap-3 jungle-achievements-grid">
-            <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>
-              <div className="jungle-achievement-icon text-lg sm:text-2xl">🌿</div>
+            <div
+              className="jungle-achievement-item p-2 sm:p-3"
+              style={{ minHeight: 0 }}
+            >
+              <div className="jungle-achievement-icon text-lg sm:text-2xl">
+                🌿
+              </div>
               <div className="achievement-content">
-                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">Completed</div>
-                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">{getFilterCounts.completed}</div>
+                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">
+                  Completed
+                </div>
+                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">
+                  {getFilterCounts.completed}
+                </div>
               </div>
             </div>
-            <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>
-              <div className="jungle-achievement-icon text-lg sm:text-2xl">🧭</div>
+            <div
+              className="jungle-achievement-item p-2 sm:p-3"
+              style={{ minHeight: 0 }}
+            >
+              <div className="jungle-achievement-icon text-lg sm:text-2xl">
+                🧭
+              </div>
               <div className="achievement-content">
-                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">In Progress</div>
-                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">{getFilterCounts["in-progress"]}</div>
+                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">
+                  In Progress
+                </div>
+                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">
+                  {getFilterCounts["in-progress"]}
+                </div>
               </div>
             </div>
-            <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>
-              <div className="jungle-achievement-icon text-lg sm:text-2xl">⭐</div>
+            <div
+              className="jungle-achievement-item p-2 sm:p-3"
+              style={{ minHeight: 0 }}
+            >
+              <div className="jungle-achievement-icon text-lg sm:text-2xl">
+                ⭐
+              </div>
               <div className="achievement-content">
-                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">Recommended</div>
-                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">{getFilterCounts.recommended}</div>
+                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">
+                  Recommended
+                </div>
+                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">
+                  {getFilterCounts.recommended}
+                </div>
               </div>
             </div>
           </div>
@@ -567,8 +594,10 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
               </div>
               {/* Milestone gems */}
               <div className="flex justify-between text-emerald-700 text-[10px] sm:text-xs mt-1 px-0.5">
-                {[0,25,50,75,100].map((m) => (
-                  <span key={m} className="opacity-70 select-none">{m}%</span>
+                {[0, 25, 50, 75, 100].map((m) => (
+                  <span key={m} className="opacity-70 select-none">
+                    {m}%
+                  </span>
                 ))}
               </div>
             </div>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -494,7 +494,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
-        <div className="jungle-progress-container p-2 sm:p-4 -mt-2 sm:mt-0 mb-3 overflow-visible">
+        <div className="jungle-progress-container p-2 sm:p-4 -mt-4 sm:mt-0 mb-4 overflow-visible relative z-10">
           {/* Jungle quick stats - playful badges */}
           <div className="grid grid-cols-3 gap-1 sm:gap-3 jungle-achievements-grid">
             <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -494,7 +494,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
-        <div className="jungle-progress-container p-3 sm:p-4">
+        <div className="jungle-progress-container p-2 sm:p-4 -mt-1 sm:mt-0 mb-2 overflow-visible">
           {/* Jungle quick stats - playful badges */}
           <div className="grid grid-cols-3 gap-1 sm:gap-3 jungle-achievements-grid">
             <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -496,26 +496,26 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
       {categories.length > 0 && (
         <div className="jungle-progress-container p-3 sm:p-4">
           {/* Jungle quick stats - playful badges */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-3 jungle-achievements-grid">
-            <div className="jungle-achievement-item">
-              <div className="jungle-achievement-icon">🌿</div>
+          <div className="grid grid-cols-3 gap-1 sm:gap-3 jungle-achievements-grid">
+            <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>
+              <div className="jungle-achievement-icon text-lg sm:text-2xl">🌿</div>
               <div className="achievement-content">
-                <div className="font-bold text-jungle-green text-sm">Completed</div>
-                <div className="font-bold text-sunshine-yellow text-lg">{getFilterCounts.completed}</div>
+                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">Completed</div>
+                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">{getFilterCounts.completed}</div>
               </div>
             </div>
-            <div className="jungle-achievement-item">
-              <div className="jungle-achievement-icon">🧭</div>
+            <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>
+              <div className="jungle-achievement-icon text-lg sm:text-2xl">🧭</div>
               <div className="achievement-content">
-                <div className="font-bold text-jungle-green text-sm">In Progress</div>
-                <div className="font-bold text-sunshine-yellow text-lg">{getFilterCounts["in-progress"]}</div>
+                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">In Progress</div>
+                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">{getFilterCounts["in-progress"]}</div>
               </div>
             </div>
-            <div className="jungle-achievement-item">
-              <div className="jungle-achievement-icon">⭐</div>
+            <div className="jungle-achievement-item p-2 sm:p-3" style={{ minHeight: 0 }}>
+              <div className="jungle-achievement-icon text-lg sm:text-2xl">⭐</div>
               <div className="achievement-content">
-                <div className="font-bold text-jungle-green text-sm">Recommended</div>
-                <div className="font-bold text-sunshine-yellow text-lg">{getFilterCounts.recommended}</div>
+                <div className="font-bold text-jungle-green text-[10px] sm:text-sm">Recommended</div>
+                <div className="font-bold text-sunshine-yellow text-sm sm:text-lg">{getFilterCounts.recommended}</div>
               </div>
             </div>
           </div>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -6,6 +6,7 @@ import { useReward } from "@/contexts/RewardContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import {
   Search,
   Filter,
@@ -41,6 +42,11 @@ interface CategoryGridProps {
   showDifficulty?: boolean;
   showProgress?: boolean;
   maxCategories?: number;
+  // Overall learning journey progress (moved here from ExplorerShell footer)
+  progress?: {
+    current: number;
+    total: number;
+  };
 }
 
 type FilterType =
@@ -69,6 +75,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
   showDifficulty = true,
   showProgress = true,
   maxCategories,
+  progress,
 }) => {
   const { showReward } = useReward();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
@@ -495,6 +502,36 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
               <span>{getFilterCounts.recommended} recommended</span>
             </div>
           </div>
+
+          {/* Learning Journey Progress (moved from ExplorerShell footer) */}
+          {progress && (
+            <div className="mt-3 w-full max-w-3xl mx-auto">
+              <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-1">
+                <span className="text-sm font-medium text-gray-700">Learning Journey</span>
+                <span className="text-sm text-gray-600 whitespace-normal break-words">
+                  {progress.current} of {progress.total} completed
+                </span>
+              </div>
+              <div className="relative h-3 bg-green-100 rounded-full overflow-hidden">
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${(progress.current / progress.total) * 100}%` }}
+                  transition={{ duration: 0.6, ease: "easeOut" }}
+                  className="h-full bg-gradient-to-r from-green-400 to-green-600 rounded-full relative overflow-hidden"
+                >
+                  <div className="absolute inset-0 opacity-30">
+                    <div
+                      className="h-full w-full bg-repeat-x bg-center"
+                      style={{
+                        backgroundImage:
+                          "url(\"data:image/svg+xml,%3Csvg width='20' height='12' viewBox='0 0 20 12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 6c2-2 4-2 6 0s4 2 6 0' stroke='%23ffffff' stroke-width='1' fill='none'/%3E%3C/svg%3E\")",
+                      }}
+                    />
+                  </div>
+                </motion.div>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -319,7 +319,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
           {/* Filter Buttons */}
           {showFilters && (
-            <div className="flex flex-wrap items-center gap-2 justify-center md:justify-start">
+            <div className="flex flex-wrap items-center gap-2 justify-start">
               {filterButtons.map(({ key, label, icon }) => {
                 const count = getFilterCounts[key];
                 const isActive = activeFilter === key;
@@ -335,6 +335,9 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                     className={cn(
                       "rounded-full transition-all duration-200",
                       isActive && "shadow-md scale-105",
+                      key === "all" && "order-1",
+                      key === "recommended" && "order-2",
+                      key !== "all" && key !== "recommended" && "order-4",
                     )}
                     aria-label={`Filter by ${label}`}
                     aria-pressed={isActive}
@@ -361,7 +364,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                   onClick={handleClearFilters}
                   variant="outline"
                   size="sm"
-                  className="rounded-full"
+                  className="rounded-full order-3 md:order-none ml-1"
                   aria-label="Clear all filters"
                 >
                   <RotateCcw className="w-3 h-3 mr-1" />

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -521,11 +521,11 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                 <span className="text-sm sm:text-base font-semibold text-emerald-800 flex items-center gap-1">
                   <span className="select-none">🌿</span> Learning Journey
                 </span>
-                <span className="text-xs sm:text-sm text-emerald-900">
+                <span className="text-xs sm:text-sm font-semibold text-emerald-900">
                   {progress.current} of {progress.total} completed
                 </span>
               </div>
-              <div className="relative h-3 sm:h-3.5 bg-gradient-to-r from-emerald-50 to-green-100 rounded-full overflow-hidden border border-green-200">
+              <div className="relative h-3 sm:h-3.5 bg-emerald-200 rounded-full overflow-hidden border border-emerald-400">
                 <motion.div
                   initial={{ width: 0 }}
                   animate={{ width: `${progressPercent}%` }}
@@ -549,7 +549,7 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                   initial={{ opacity: 0, y: -6 }}
                   animate={{ opacity: 1, y: -6 }}
                   transition={{ delay: 0.2 }}
-                  className="absolute top-1/2 -translate-y-1/2 text-base sm:text-lg drop-shadow"
+                  className="absolute top-1/2 -translate-y-1/2 text-base sm:text-lg drop-shadow-md"
                   style={{ left: `calc(${progressPercent}% - 10px)` }}
                   aria-hidden
                 >

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -279,6 +279,13 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
     });
   }
 
+  // Calculate overall progress percent for themed progress bar
+  const progressPercent = useMemo(() => {
+    if (!progress) return 0;
+    const pct = (progress.current / Math.max(progress.total || 1, 1)) * 100;
+    return Math.max(0, Math.min(100, pct));
+  }, [progress?.current, progress?.total]);
+
   return (
     <div className={cn("space-y-4", className)}>
       {/* Search and Filters Header */}
@@ -488,37 +495,45 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
         <div className="mt-6 pt-4 border-t border-gray-200">
-          <div className="flex flex-wrap justify-center gap-4 text-sm text-gray-600">
-            <div className="flex items-center gap-1">
-              <CheckCircle className="w-4 h-4 text-green-500" />
-              <span>{getFilterCounts.completed} completed</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <Play className="w-4 h-4 text-blue-500" />
-              <span>{getFilterCounts["in-progress"]} in progress</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <Star className="w-4 h-4 text-yellow-500" />
-              <span>{getFilterCounts.recommended} recommended</span>
-            </div>
+          {/* Jungle quick stats - playful badges */}
+          <div className="flex flex-wrap justify-center gap-2 sm:gap-3 text-xs sm:text-sm">
+            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-50/80 text-green-800 border border-green-200 shadow-sm" aria-label={`${getFilterCounts.completed} completed categories`}>
+              <span>🌿</span>
+              <span className="font-semibold">{getFilterCounts.completed}</span>
+              <span className="opacity-80">completed</span>
+            </span>
+            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-sky-50/80 text-sky-800 border border-sky-200 shadow-sm" aria-label={`${getFilterCounts["in-progress"]} in progress categories`}>
+              <span>🧭</span>
+              <span className="font-semibold">{getFilterCounts["in-progress"]}</span>
+              <span className="opacity-80">in progress</span>
+            </span>
+            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-50/80 text-yellow-900 border border-yellow-200 shadow-sm" aria-label={`${getFilterCounts.recommended} recommended categories`}>
+              <span>⭐</span>
+              <span className="font-semibold">{getFilterCounts.recommended}</span>
+              <span className="opacity-80">recommended</span>
+            </span>
           </div>
 
-          {/* Learning Journey Progress (moved from ExplorerShell footer) */}
+          {/* Learning Journey Progress (immersive jungle style) */}
           {progress && (
             <div className="mt-3 w-full max-w-3xl mx-auto">
               <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-1">
-                <span className="text-sm font-medium text-gray-700">Learning Journey</span>
-                <span className="text-sm text-gray-600 whitespace-normal break-words">
+                <span className="text-sm sm:text-base font-semibold text-emerald-800 flex items-center gap-1">
+                  <span className="select-none">🌿</span> Learning Journey
+                </span>
+                <span className="text-xs sm:text-sm text-emerald-900 bg-white/60 border border-white/40 rounded-full px-2 py-0.5">
                   {progress.current} of {progress.total} completed
                 </span>
               </div>
-              <div className="relative h-3 bg-green-100 rounded-full overflow-hidden">
+              <div className="relative h-3 sm:h-3.5 bg-gradient-to-r from-emerald-50 to-green-100 rounded-full overflow-hidden border border-green-200">
                 <motion.div
                   initial={{ width: 0 }}
-                  animate={{ width: `${(progress.current / progress.total) * 100}%` }}
+                  animate={{ width: `${progressPercent}%` }}
                   transition={{ duration: 0.6, ease: "easeOut" }}
-                  className="h-full bg-gradient-to-r from-green-400 to-green-600 rounded-full relative overflow-hidden"
+                  className="h-full bg-gradient-to-r from-green-400 via-green-500 to-emerald-600 rounded-full relative overflow-hidden"
+                  aria-label="Learning journey progress"
                 >
+                  {/* Vine pattern overlay */}
                   <div className="absolute inset-0 opacity-30">
                     <div
                       className="h-full w-full bg-repeat-x bg-center"
@@ -529,6 +544,23 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
                     />
                   </div>
                 </motion.div>
+                {/* Floating leaf marker */}
+                <motion.div
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: -6 }}
+                  transition={{ delay: 0.2 }}
+                  className="absolute top-1/2 -translate-y-1/2 text-base sm:text-lg drop-shadow"
+                  style={{ left: `calc(${progressPercent}% - 10px)` }}
+                  aria-hidden
+                >
+                  🍃
+                </motion.div>
+              </div>
+              {/* Milestone gems */}
+              <div className="flex justify-between text-emerald-700 text-[10px] sm:text-xs mt-1 px-0.5">
+                {[0,25,50,75,100].map((m) => (
+                  <span key={m} className="opacity-70 select-none">{m}%</span>
+                ))}
               </div>
             </div>
           )}

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -494,24 +494,30 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
-        <div className="mt-4">
+        <div className="jungle-progress-container">
           {/* Jungle quick stats - playful badges */}
-          <div className="flex flex-wrap justify-center gap-2 sm:gap-3 text-xs sm:text-sm">
-            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-emerald-600 text-white border border-emerald-700 shadow-sm" aria-label={`${getFilterCounts.completed} completed categories`}>
-              <span>🌿</span>
-              <span className="font-semibold">{getFilterCounts.completed}</span>
-              <span className="font-medium">completed</span>
-            </span>
-            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-sky-600 text-white border border-sky-700 shadow-sm" aria-label={`${getFilterCounts["in-progress"]} in progress categories`}>
-              <span>🧭</span>
-              <span className="font-semibold">{getFilterCounts["in-progress"]}</span>
-              <span className="font-medium">in progress</span>
-            </span>
-            <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-500 text-white border border-yellow-600 shadow-sm" aria-label={`${getFilterCounts.recommended} recommended categories`}>
-              <span>⭐</span>
-              <span className="font-semibold">{getFilterCounts.recommended}</span>
-              <span className="font-medium">recommended</span>
-            </span>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 jungle-achievements-grid">
+            <div className="jungle-achievement-item">
+              <div className="jungle-achievement-icon">🌿</div>
+              <div className="achievement-content">
+                <div className="font-bold text-jungle-green text-sm">Completed</div>
+                <div className="font-bold text-sunshine-yellow text-lg">{getFilterCounts.completed}</div>
+              </div>
+            </div>
+            <div className="jungle-achievement-item">
+              <div className="jungle-achievement-icon">🧭</div>
+              <div className="achievement-content">
+                <div className="font-bold text-jungle-green text-sm">In Progress</div>
+                <div className="font-bold text-sunshine-yellow text-lg">{getFilterCounts["in-progress"]}</div>
+              </div>
+            </div>
+            <div className="jungle-achievement-item">
+              <div className="jungle-achievement-icon">⭐</div>
+              <div className="achievement-content">
+                <div className="font-bold text-jungle-green text-sm">Recommended</div>
+                <div className="font-bold text-sunshine-yellow text-lg">{getFilterCounts.recommended}</div>
+              </div>
+            </div>
           </div>
 
           {/* Learning Journey Progress (immersive jungle style) */}

--- a/client/components/category/CategoryGrid.tsx
+++ b/client/components/category/CategoryGrid.tsx
@@ -494,9 +494,9 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
 
       {/* Quick Stats Footer */}
       {categories.length > 0 && (
-        <div className="jungle-progress-container">
+        <div className="jungle-progress-container p-3 sm:p-4">
           {/* Jungle quick stats - playful badges */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 jungle-achievements-grid">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-3 jungle-achievements-grid">
             <div className="jungle-achievement-item">
               <div className="jungle-achievement-icon">🌿</div>
               <div className="achievement-content">
@@ -524,14 +524,14 @@ export const CategoryGrid: React.FC<CategoryGridProps> = ({
           {progress && (
             <div className="mt-3 w-full max-w-3xl mx-auto">
               <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-1">
-                <span className="text-sm sm:text-base font-semibold text-emerald-800 flex items-center gap-1">
+                <span className="text-xs sm:text-sm font-semibold text-white flex items-center gap-1">
                   <span className="select-none">🌿</span> Learning Journey
                 </span>
-                <span className="text-xs sm:text-sm font-semibold text-emerald-900">
+                <span className="text-xs sm:text-sm font-semibold text-white">
                   {progress.current} of {progress.total} completed
                 </span>
               </div>
-              <div className="relative h-3 sm:h-3.5 bg-emerald-200 rounded-full overflow-hidden border border-emerald-400">
+              <div className="relative h-2 sm:h-3 bg-emerald-200 rounded-full overflow-hidden border border-emerald-400">
                 <motion.div
                   initial={{ width: 0 }}
                   animate={{ width: `${progressPercent}%` }}

--- a/client/components/category/CategoryTile.tsx
+++ b/client/components/category/CategoryTile.tsx
@@ -179,7 +179,7 @@ export const CategoryTile: React.FC<CategoryTileProps> = ({
       )}
 
       {/* Status badges */}
-      <div className="absolute top-2 left-2 flex flex-col gap-1">
+      <div className="absolute top-2 left-2 flex flex-row flex-wrap items-center gap-1">
         {recommended && (
           <Badge className="bg-yellow-400 text-yellow-900 text-xs px-2 py-1 animate-pulse">
             ⭐ For You

--- a/client/components/category/CategoryTile.tsx
+++ b/client/components/category/CategoryTile.tsx
@@ -191,7 +191,7 @@ export const CategoryTile: React.FC<CategoryTileProps> = ({
           {getDifficultyLabel()}
         </Badge>
         {estimatedTime && (
-          <Badge className="bg-white/25 border-white/40 text-gray-700 text-xs px-2 py-1">
+          <Badge className="bg-emerald-600 border-emerald-700 text-white text-xs px-2 py-1">
             <Clock className="w-3 h-3 mr-1" />
             {estimatedTime}
           </Badge>
@@ -268,11 +268,11 @@ export const CategoryTile: React.FC<CategoryTileProps> = ({
         <div className="w-full space-y-1">
           {/* Progress bar with vine pattern */}
           <div className="relative">
-            <Progress value={progress} className="h-2 bg-white/50" />
+            <Progress value={progress} className="h-2 bg-emerald-100" />
             {/* Vine overlay pattern */}
             {progress > 0 && (
               <div
-                className="absolute top-0 left-0 h-2 bg-green-500 rounded-full opacity-70"
+                className="absolute top-0 left-0 h-2 bg-green-500 rounded-full"
                 style={{
                   width: `${progress}%`,
                   backgroundImage: `url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 8 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 1c1-1 2-1 3 0s2 1 3 0' stroke='%23ffffff' stroke-width='0.5' fill='none'/%3E%3C/svg%3E")`,
@@ -315,7 +315,7 @@ export const CategoryTile: React.FC<CategoryTileProps> = ({
       {/* Difficulty mix indicator */}
       {difficultyMix.easy + difficultyMix.medium + difficultyMix.hard > 0 && (
         <div className="absolute bottom-2 left-2 right-2">
-          <div className="flex h-1 rounded-full overflow-hidden bg-white/30">
+          <div className="flex h-1 rounded-full overflow-hidden bg-emerald-200">
             {difficultyMix.easy > 0 && (
               <div
                 className="bg-green-400"

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -389,7 +389,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
         {/* Mobile Controls */}
         <div className="md:hidden px-2 pb-1 space-y-1">
           {/* Mode Navigation (Mobile) */}
-          <div className="flex bg-white/70 border border-white/60 rounded-full p-1 shadow-md">
+          <div className="flex bg-white/60 border border-white/50 rounded-full p-0.5 shadow">
             <Button
               onClick={() => handleModeClick("map")}
               variant={mode === "map" ? "default" : "secondary"}

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -394,7 +394,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
               onClick={() => handleModeClick("map")}
               variant={mode === "map" ? "default" : "secondary"}
               size="sm"
-              className="rounded-full flex-1 shadow-sm transition-all active:scale-95"
+              className="rounded-full flex-1 shadow-sm transition-all active:scale-95 h-8 text-xs"
             >
               <Map className="w-4 h-4 mr-1" />
               Map
@@ -403,7 +403,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
               onClick={() => handleModeClick("adventure")}
               variant={mode === "adventure" ? "default" : "secondary"}
               size="sm"
-              className="rounded-full flex-1 shadow-sm transition-all active:scale-95"
+              className="rounded-full flex-1 shadow-sm transition-all active:scale-95 h-8 text-xs"
             >
               <Target className="w-4 h-4 mr-1" />
               Adventure
@@ -412,7 +412,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
               onClick={() => handleModeClick("favorites")}
               variant={mode === "favorites" ? "default" : "secondary"}
               size="sm"
-              className="rounded-full flex-1 shadow-sm transition-all active:scale-95"
+              className="rounded-full flex-1 shadow-sm transition-all active:scale-95 h-8 text-xs"
             >
               <Heart className="w-4 h-4 mr-1" />
               Favorites

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -387,7 +387,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
         </div>
 
         {/* Mobile Controls */}
-        <div className="md:hidden px-2 pb-2 space-y-2">
+        <div className="md:hidden px-2 pb-1 space-y-1">
           {/* Mode Navigation (Mobile) */}
           <div className="flex bg-white/70 border border-white/60 rounded-full p-1 shadow-md">
             <Button

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -489,11 +489,11 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
       {progress && (
         <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50">
           <div className="max-w-7xl mx-auto px-4 py-3">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-gray-700">
+            <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
+              <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">
                 Learning Journey
               </span>
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-gray-600 whitespace-normal break-words">
                 {progress.current} of {progress.total} completed
               </span>
             </div>

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -118,7 +118,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
   return (
     <div
       className={cn(
-        "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-contain bg-top md:bg-center bg-no-repeat bg-emerald-50",
+        "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-cover bg-center bg-no-repeat",
         "relative overflow-hidden pb-14 md:pb-16 lg:pb-16 safe-area-padding-bottom",
         className,
       )}
@@ -178,7 +178,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
       </div>
 
       {/* Header */}
-      <header className="relative z-10 bg-gradient-to-b from-white/40 to-white/10 backdrop-blur-md border-b border-white/30 shadow-lg">
+      <header className="relative z-10 bg-transparent">
         <div className="max-w-7xl mx-auto px-2 py-1 md:px-4 md:py-4">
           <div className="flex items-center justify-between">
             {/* Left: Back button and title */}
@@ -479,7 +479,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
       {/* Progress Footer (Vine Bar) */}
       {progress && (
-        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50 mb-14 md:mb-16 lg:mb-16 safe-area-margin-bottom">
+        <footer className="relative z-10 bg-transparent mb-14 md:mb-16 lg:mb-16 safe-area-margin-bottom">
           <div className="max-w-7xl mx-auto px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
               <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -127,7 +127,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
       }}
     >
       {/* Animated background elements */}
-      <div className="hidden absolute inset-0 pointer-events-none">
+      <div className="absolute inset-0 pointer-events-none z-0">
         {!reducedMotion && (
           <>
             <motion.div
@@ -176,6 +176,9 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
           </>
         )}
       </div>
+      {/* Jungle depth gradients */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-16 bg-gradient-to-b from-emerald-900/10 to-transparent z-0" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-emerald-900/10 to-transparent z-0" />
 
       {/* Header */}
       <header className="relative z-10 bg-transparent">
@@ -223,7 +226,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
             {/* Center: Mode Navigation (Desktop) */}
             <div className="hidden md:flex items-center gap-2">
-              <div className="flex bg-white/70 border border-white/60 rounded-full p-1 shadow-md">
+              <div className="flex bg-emerald-900/10 border border-emerald-900/20 rounded-full p-1 shadow-md">
                 <Button
                   onClick={() => handleModeClick("map")}
                   variant={mode === "map" ? "default" : "secondary"}
@@ -354,7 +357,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
               {/* Stats Display (Desktop) */}
               {showStats && (
-                <div className="hidden lg:flex items-center gap-3 px-3 py-1 bg-white/60 rounded-full border border-white/40 shadow-md">
+                <div className="hidden lg:flex items-center gap-3 px-3 py-1 bg-emerald-900/15 rounded-full border border-emerald-900/20 shadow-md">
                   <div className="flex items-center gap-1">
                     <Gem className="w-4 h-4 text-blue-500" />
                     <span className="text-sm font-bold">{gems}</span>
@@ -389,7 +392,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
         {/* Mobile Controls */}
         <div className="md:hidden px-2 pb-1 space-y-1">
           {/* Mode Navigation (Mobile) */}
-          <div className="flex bg-white/60 border border-white/50 rounded-full p-0.5 shadow">
+          <div className="flex bg-emerald-900/10 border border-emerald-900/20 rounded-full p-0.5 shadow">
             <Button
               onClick={() => handleModeClick("map")}
               variant={mode === "map" ? "default" : "secondary"}
@@ -422,15 +425,15 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
           {/* Mobile Stats */}
           {showStats && (
             <div className="flex items-center justify-center gap-2 py-1">
-              <div className="flex items-center gap-1 bg-blue-100 rounded-full px-3 py-1">
+              <div className="flex items-center gap-1 bg-blue-900/20 border border-blue-900/20 rounded-full px-3 py-1">
                 <Gem className="w-3 h-3 text-blue-600" />
                 <span className="text-xs font-bold text-blue-700">{gems}</span>
               </div>
-              <div className="flex items-center gap-1 bg-red-100 rounded-full px-3 py-1">
+              <div className="flex items-center gap-1 bg-red-900/20 border border-red-900/20 rounded-full px-3 py-1">
                 <Flame className="w-3 h-3 text-red-600" />
                 <span className="text-xs font-bold text-red-700">{streak}</span>
               </div>
-              <div className="flex items-center gap-1 bg-green-100 rounded-full px-3 py-1">
+              <div className="flex items-center gap-1 bg-green-900/20 border border-green-900/20 rounded-full px-3 py-1">
                 <Timer className="w-3 h-3 text-green-600" />
                 <span className="text-xs font-bold text-green-700">
                   {formatTime(sessionTime)}
@@ -491,7 +494,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
             </div>
 
             {/* Vine Progress Bar */}
-            <div className="relative h-3 bg-green-100 rounded-full overflow-hidden">
+            <div className="relative h-3 bg-emerald-900/15 rounded-full overflow-hidden">
               <motion.div
                 initial={{ width: 0 }}
                 animate={{

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -434,35 +434,6 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
             </div>
           )}
 
-          {/* Quick Category Select */}
-          {categories.length > 0 && mode === "map" && (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-semibold text-gray-700">
-                  Quick Select
-                </span>
-              </div>
-              <div className="flex gap-2 overflow-x-auto pb-2">
-                {categories.map((category) => (
-                  <Button
-                    key={category.id}
-                    onClick={() => onCategorySelect?.(category.id)}
-                    className={cn(
-                      "rounded-full min-w-[80px] h-10 px-3 text-sm flex-shrink-0 shadow-sm",
-                      selectedCategory === category.id
-                        ? "bg-gradient-to-r from-green-400 to-blue-500 text-white"
-                        : "bg-white border border-gray-200 text-gray-700 hover:bg-gray-50",
-                    )}
-                    aria-label={`Select ${category.name} category`}
-                  >
-                    <span className="mr-1 text-base">{category.emoji}</span>
-                    {category.name}
-                    {category.recommended && <span className="ml-1">⭐</span>}
-                  </Button>
-                ))}
-              </div>
-            </div>
-          )}
 
           {/* Progress Bar */}
           {progress && (

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -127,7 +127,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
       }}
     >
       {/* Animated background elements */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+      <div className="hidden absolute inset-0 pointer-events-none">
         {!reducedMotion && (
           <>
             <motion.div

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -261,16 +261,36 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
             <div className="flex items-center gap-1 md:gap-2">
               {/* Search (Desktop) */}
               {showSearch && (
-                <div className="hidden sm:block relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-                  <input
-                    type="text"
-                    placeholder="Search words..."
-                    value={searchQuery}
-                    onChange={(e) => onSearchChange?.(e.target.value)}
-                    className="pl-10 pr-4 py-2 border border-gray-200 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-48"
-                    aria-label="Search words"
-                  />
+                <div className="relative">
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowMobileSearch((s) => !s);
+                    }}
+                    variant="secondary"
+                    size="sm"
+                    className="rounded-full w-9 h-9 p-0"
+                    aria-label={showMobileSearch ? "Close search" : "Open search"}
+                  >
+                    <Search className="w-4 h-4" />
+                  </Button>
+                  {/* Desktop dropdown search */}
+                  {showMobileSearch && (
+                    <div className="hidden sm:block absolute right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg p-2 w-64 z-50">
+                      <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                        <input
+                          type="text"
+                          placeholder="Search words..."
+                          value={searchQuery}
+                          onChange={(e) => onSearchChange?.(e.target.value)}
+                          className="w-full pl-10 pr-3 py-2 border border-gray-200 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          aria-label="Search words"
+                          autoFocus
+                        />
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -420,7 +440,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
           )}
 
           {/* Mobile Search */}
-          {showSearch && (
+          {showSearch && showMobileSearch && (
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
               <input
@@ -430,6 +450,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                 onChange={(e) => onSearchChange?.(e.target.value)}
                 className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                 aria-label="Search words"
+                autoFocus
               />
             </div>
           )}

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -118,7 +118,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
   return (
     <div
       className={cn(
-        "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-cover bg-center bg-no-repeat",
+        "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-contain bg-top md:bg-center bg-no-repeat bg-emerald-50",
         "relative overflow-hidden pb-14 md:pb-16 lg:pb-16 safe-area-padding-bottom",
         className,
       )}

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -273,7 +273,9 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                     variant="secondary"
                     size="sm"
                     className="rounded-full w-9 h-9 p-0"
-                    aria-label={showMobileSearch ? "Close search" : "Open search"}
+                    aria-label={
+                      showMobileSearch ? "Close search" : "Open search"
+                    }
                   >
                     <Search className="w-4 h-4" />
                   </Button>
@@ -458,7 +460,6 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
             </div>
           )}
 
-
           {/* Progress Bar */}
           {progress && (
             <div className="space-y-1">
@@ -520,7 +521,9 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                 animate={{ opacity: 1, y: -6 }}
                 transition={{ delay: 0.2 }}
                 className="absolute top-1/2 -translate-y-1/2 text-base drop-shadow-md"
-                style={{ left: `calc(${(progress.current / progress.total) * 100}% - 10px)` }}
+                style={{
+                  left: `calc(${(progress.current / progress.total) * 100}% - 10px)`,
+                }}
                 aria-hidden
               >
                 🍃

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -179,7 +179,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
       {/* Header */}
       <header className="relative z-10 bg-gradient-to-b from-white/40 to-white/10 backdrop-blur-md border-b border-white/30 shadow-lg">
-        <div className="max-w-7xl mx-auto px-2 py-2 md:px-4 md:py-4">
+        <div className="max-w-7xl mx-auto px-2 py-1 md:px-4 md:py-4">
           <div className="flex items-center justify-between">
             {/* Left: Back button and title */}
             <div className="flex items-center gap-4">
@@ -205,13 +205,13 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                     repeat: Infinity,
                     ease: "easeInOut",
                   }}
-                  className="text-2xl md:text-3xl"
+                  className="text-xl md:text-3xl"
                 >
                   🦉
                 </motion.div>
 
                 <div>
-                  <h1 className="text-lg md:text-2xl font-bold bg-gradient-to-r from-green-600 to-blue-600 bg-clip-text text-transparent">
+                  <h1 className="text-base md:text-2xl font-bold bg-gradient-to-r from-green-600 to-blue-600 bg-clip-text text-transparent">
                     {title}
                   </h1>
                   <p className="hidden md:block text-sm text-gray-600">
@@ -421,18 +421,18 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
           {/* Mobile Stats */}
           {showStats && (
-            <div className="flex items-center justify-center gap-4 py-2">
+            <div className="flex items-center justify-center gap-2 py-1">
               <div className="flex items-center gap-1 bg-blue-100 rounded-full px-3 py-1">
-                <Gem className="w-4 h-4 text-blue-600" />
-                <span className="text-sm font-bold text-blue-700">{gems}</span>
+                <Gem className="w-3 h-3 text-blue-600" />
+                <span className="text-xs font-bold text-blue-700">{gems}</span>
               </div>
               <div className="flex items-center gap-1 bg-red-100 rounded-full px-3 py-1">
-                <Flame className="w-4 h-4 text-red-600" />
-                <span className="text-sm font-bold text-red-700">{streak}</span>
+                <Flame className="w-3 h-3 text-red-600" />
+                <span className="text-xs font-bold text-red-700">{streak}</span>
               </div>
               <div className="flex items-center gap-1 bg-green-100 rounded-full px-3 py-1">
-                <Timer className="w-4 h-4 text-green-600" />
-                <span className="text-sm font-bold text-green-700">
+                <Timer className="w-3 h-3 text-green-600" />
+                <span className="text-xs font-bold text-green-700">
                   {formatTime(sessionTime)}
                 </span>
               </div>

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -119,7 +119,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
     <div
       className={cn(
         "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-cover bg-center bg-no-repeat",
-        "relative overflow-hidden pb-24 md:pb-28 lg:pb-32 safe-area-padding-bottom",
+        "relative overflow-hidden pb-40 md:pb-44 lg:pb-48 safe-area-padding-bottom",
         className,
       )}
       style={{
@@ -487,7 +487,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
       {/* Progress Footer (Vine Bar) */}
       {progress && (
-        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50 mb-24 md:mb-28 lg:mb-32 safe-area-margin-bottom">
+        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50 mb-40 md:mb-44 lg:mb-48 safe-area-margin-bottom">
           <div className="max-w-7xl mx-auto px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
               <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -119,7 +119,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
     <div
       className={cn(
         "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-cover bg-center bg-no-repeat",
-        "relative overflow-hidden",
+        "relative overflow-hidden pb-24 md:pb-28 lg:pb-32 safe-area-padding-bottom",
         className,
       )}
       style={{
@@ -487,7 +487,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
       {/* Progress Footer (Vine Bar) */}
       {progress && (
-        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50">
+        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50 mb-24 md:mb-28 lg:mb-32 safe-area-margin-bottom">
           <div className="max-w-7xl mx-auto px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
               <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -485,16 +485,16 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
         <footer className="relative z-10 bg-transparent mb-14 md:mb-16 lg:mb-16 safe-area-margin-bottom">
           <div className="max-w-7xl mx-auto px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
-              <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">
+              <span className="text-sm font-semibold text-emerald-900 whitespace-normal break-words">
                 Learning Journey
               </span>
-              <span className="text-sm text-gray-600 whitespace-normal break-words">
+              <span className="text-sm font-semibold text-emerald-900 whitespace-normal break-words">
                 {progress.current} of {progress.total} completed
               </span>
             </div>
 
             {/* Vine Progress Bar */}
-            <div className="relative h-3 bg-emerald-900/15 rounded-full overflow-hidden">
+            <div className="relative h-3 bg-emerald-200 rounded-full overflow-hidden border border-emerald-400">
               <motion.div
                 initial={{ width: 0 }}
                 animate={{
@@ -512,6 +512,18 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                     }}
                   />
                 </div>
+              </motion.div>
+
+              {/* Leaf marker */}
+              <motion.div
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: -6 }}
+                transition={{ delay: 0.2 }}
+                className="absolute top-1/2 -translate-y-1/2 text-base drop-shadow-md"
+                style={{ left: `calc(${(progress.current / progress.total) * 100}% - 10px)` }}
+                aria-hidden
+              >
+                🍃
               </motion.div>
 
               {/* Progress gems */}

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -178,7 +178,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
       </div>
 
       {/* Header */}
-      <header className="relative z-10 bg-white/80 backdrop-blur-sm border-b border-white/50 shadow-sm">
+      <header className="relative z-10 bg-gradient-to-b from-white/40 to-white/10 backdrop-blur-md border-b border-white/30 shadow-lg">
         <div className="max-w-7xl mx-auto px-2 py-2 md:px-4 md:py-4">
           <div className="flex items-center justify-between">
             {/* Left: Back button and title */}
@@ -223,12 +223,12 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
             {/* Center: Mode Navigation (Desktop) */}
             <div className="hidden md:flex items-center gap-2">
-              <div className="flex bg-white border border-gray-200 rounded-full p-1 shadow-sm">
+              <div className="flex bg-white/70 border border-white/60 rounded-full p-1 shadow-md">
                 <Button
                   onClick={() => handleModeClick("map")}
                   variant={mode === "map" ? "default" : "secondary"}
                   size="sm"
-                  className="rounded-full px-4"
+                  className="rounded-full px-4 shadow-sm transition-all hover:scale-105"
                   aria-label="Map mode"
                 >
                   <Map className="w-4 h-4 mr-2" />
@@ -238,7 +238,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                   onClick={() => handleModeClick("adventure")}
                   variant={mode === "adventure" ? "default" : "secondary"}
                   size="sm"
-                  className="rounded-full px-4"
+                  className="rounded-full px-4 shadow-sm transition-all hover:scale-105"
                   aria-label="Adventure mode"
                 >
                   <Target className="w-4 h-4 mr-2" />
@@ -248,7 +248,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
                   onClick={() => handleModeClick("favorites")}
                   variant={mode === "favorites" ? "default" : "secondary"}
                   size="sm"
-                  className="rounded-full px-4"
+                  className="rounded-full px-4 shadow-sm transition-all hover:scale-105"
                   aria-label="Favorites mode"
                 >
                   <Heart className="w-4 h-4 mr-2" />
@@ -354,7 +354,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
               {/* Stats Display (Desktop) */}
               {showStats && (
-                <div className="hidden lg:flex items-center gap-3 px-3 py-1 bg-white/80 rounded-full border border-gray-200">
+                <div className="hidden lg:flex items-center gap-3 px-3 py-1 bg-white/60 rounded-full border border-white/40 shadow-md">
                   <div className="flex items-center gap-1">
                     <Gem className="w-4 h-4 text-blue-500" />
                     <span className="text-sm font-bold">{gems}</span>
@@ -389,12 +389,12 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
         {/* Mobile Controls */}
         <div className="md:hidden px-2 pb-2 space-y-2">
           {/* Mode Navigation (Mobile) */}
-          <div className="flex bg-white border border-gray-200 rounded-full p-1 shadow-sm">
+          <div className="flex bg-white/70 border border-white/60 rounded-full p-1 shadow-md">
             <Button
               onClick={() => handleModeClick("map")}
               variant={mode === "map" ? "default" : "secondary"}
               size="sm"
-              className="rounded-full flex-1"
+              className="rounded-full flex-1 shadow-sm transition-all active:scale-95"
             >
               <Map className="w-4 h-4 mr-1" />
               Map
@@ -403,7 +403,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
               onClick={() => handleModeClick("adventure")}
               variant={mode === "adventure" ? "default" : "secondary"}
               size="sm"
-              className="rounded-full flex-1"
+              className="rounded-full flex-1 shadow-sm transition-all active:scale-95"
             >
               <Target className="w-4 h-4 mr-1" />
               Adventure
@@ -412,7 +412,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
               onClick={() => handleModeClick("favorites")}
               variant={mode === "favorites" ? "default" : "secondary"}
               size="sm"
-              className="rounded-full flex-1"
+              className="rounded-full flex-1 shadow-sm transition-all active:scale-95"
             >
               <Heart className="w-4 h-4 mr-1" />
               Favorites

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -119,7 +119,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
     <div
       className={cn(
         "min-h-screen bg-[url('/images/bg_mobile.webp')] md:bg-[url('/images/bg_tablet.webp')] lg:bg-[url('/images/bg_desktop.webp')] bg-cover bg-center bg-no-repeat",
-        "relative overflow-hidden pb-40 md:pb-44 lg:pb-48 safe-area-padding-bottom",
+        "relative overflow-hidden pb-14 md:pb-16 lg:pb-16 safe-area-padding-bottom",
         className,
       )}
       style={{
@@ -487,7 +487,7 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
 
       {/* Progress Footer (Vine Bar) */}
       {progress && (
-        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50 mb-40 md:mb-44 lg:mb-48 safe-area-margin-bottom">
+        <footer className="relative z-10 bg-white/60 backdrop-blur-sm border-t border-white/50 mb-14 md:mb-16 lg:mb-16 safe-area-margin-bottom">
           <div className="max-w-7xl mx-auto px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
               <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">

--- a/client/components/explorer/ExplorerShell.tsx
+++ b/client/components/explorer/ExplorerShell.tsx
@@ -485,16 +485,16 @@ export const ExplorerShell: React.FC<ExplorerShellProps> = ({
         <footer className="relative z-10 bg-transparent mb-14 md:mb-16 lg:mb-16 safe-area-margin-bottom">
           <div className="max-w-7xl mx-auto px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
-              <span className="text-sm font-semibold text-emerald-900 whitespace-normal break-words">
+              <span className="text-xs sm:text-sm font-semibold text-white whitespace-normal break-words">
                 Learning Journey
               </span>
-              <span className="text-sm font-semibold text-emerald-900 whitespace-normal break-words">
+              <span className="text-xs sm:text-sm font-semibold text-white whitespace-normal break-words">
                 {progress.current} of {progress.total} completed
               </span>
             </div>
 
             {/* Vine Progress Bar */}
-            <div className="relative h-3 bg-emerald-200 rounded-full overflow-hidden border border-emerald-400">
+            <div className="relative h-2 sm:h-3 bg-emerald-200 rounded-full overflow-hidden border border-emerald-400">
               <motion.div
                 initial={{ width: 0 }}
                 animate={{

--- a/client/components/word-card/WordCardUnified.tsx
+++ b/client/components/word-card/WordCardUnified.tsx
@@ -375,9 +375,9 @@ export const WordCardUnified: React.FC<WordCardUnifiedProps> = ({
   };
 
   const difficultyColors = {
-    easy: "bg-white/20 border-white/40 text-white",
-    medium: "bg-white/20 border-white/40 text-white",
-    hard: "bg-white/20 border-white/40 text-white",
+    easy: "bg-emerald-600 border-emerald-700 text-white",
+    medium: "bg-amber-600 border-amber-700 text-white",
+    hard: "bg-rose-600 border-rose-700 text-white",
   };
 
   return (
@@ -430,7 +430,7 @@ export const WordCardUnified: React.FC<WordCardUnifiedProps> = ({
               <Badge
                 variant="outline"
                 className={cn(
-                  "text-xs border-white/50",
+                  "text-xs",
                   difficultyColors[word.difficulty],
                 )}
               >
@@ -438,7 +438,7 @@ export const WordCardUnified: React.FC<WordCardUnifiedProps> = ({
               </Badge>
               <Badge
                 variant="outline"
-                className="text-xs bg-white/10 border-white/40 text-white"
+                className="text-xs bg-emerald-700 border-emerald-800 text-white"
               >
                 {word.category}
               </Badge>
@@ -556,7 +556,7 @@ export const WordCardUnified: React.FC<WordCardUnifiedProps> = ({
                   role="img"
                   aria-label={`${word.word} emoji`}
                 >
-                  {word.emoji || "📝"}
+                  {word.emoji || "����"}
                 </motion.div>
 
                 {isPlaying && (

--- a/client/components/word-card/WordCardUnified.tsx
+++ b/client/components/word-card/WordCardUnified.tsx
@@ -429,10 +429,7 @@ export const WordCardUnified: React.FC<WordCardUnifiedProps> = ({
             <div className="flex gap-2">
               <Badge
                 variant="outline"
-                className={cn(
-                  "text-xs",
-                  difficultyColors[word.difficulty],
-                )}
+                className={cn("text-xs", difficultyColors[word.difficulty])}
               >
                 {word.difficulty}
               </Badge>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -228,6 +228,16 @@ export default function Index({ initialProfile }: IndexProps) {
   });
 
   const [activeTab, setActiveTab] = useState("dashboard");
+  // Initialize active tab from URL (e.g., /app?tab=quiz)
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const tab = params.get("tab");
+      if (tab && ["dashboard", "learn", "quiz", "achievements"].includes(tab)) {
+        setActiveTab(tab);
+      }
+    } catch {}
+  }, []);
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
   const [forgottenWords, setForgottenWords] = useState<Set<number>>(new Set());
   const [rememberedWords, setRememberedWords] = useState<Set<number>>(


### PR DESCRIPTION
## Purpose
The user was experiencing layout issues in the mobile version where the progress bar was hidden and elements needed repositioning. They wanted to move containers and elements to ensure proper visibility and alignment, particularly moving elements to be beside the "All" and "For You" buttons in the same line on mobile.

## Code changes
- **CategoryGrid.tsx**: Moved progress bar from ExplorerShell footer to CategoryGrid component for better visibility
- **CategoryGrid.tsx**: Updated filter button layout to use flex-nowrap with horizontal scrolling and proper ordering (All, For You, Clear filters, other filters)
- **CategoryGrid.tsx**: Redesigned quick stats section with jungle-themed achievement badges and integrated progress bar
- **ExplorerShell.tsx**: Removed progress prop from footer, updated mobile stats styling with smaller badges and improved spacing
- **ExplorerShell.tsx**: Enhanced progress bar styling with leaf markers and emerald color scheme
- **JungleWordLibrary.tsx**: Added useNavigate hook and updated navigation logic for proper tab routing
- **JungleWordLibrary.tsx**: Moved progress prop from ExplorerShell to CategoryGrid component
- **JungleWordLibrary.tsx**: Added safe area padding for better mobile display
- **WordCardUnified.tsx**: Updated difficulty badge colors for better contrast and visibility
- **Index.tsx**: Added URL parameter handling to initialize active tab from query string

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 346`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0369b806210b4f939cd1269728a63882/pixel-zone)

👀 [Preview Link](https://0369b806210b4f939cd1269728a63882-pixel-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0369b806210b4f939cd1269728a63882</projectId>-->
<!--<branchName>pixel-zone</branchName>-->